### PR TITLE
fix: update API Key links to direct key management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-[Aliyun Model Studio CLI Site](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [中文文档](https://github.com/modelstudioai/cli/blob/main/README.zh.md) · [API Documentation](https://help.aliyun.com/zh/model-studio/) · [Get API Key](https://bailian.console.aliyun.com/cli?source_channel=key_github&)
+[Aliyun Model Studio CLI Site](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [中文文档](https://github.com/modelstudioai/cli/blob/main/README.zh.md) · [API Documentation](https://help.aliyun.com/zh/model-studio/) · [Get API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ---
 
@@ -119,7 +119,7 @@ bl usage free --model qwen3-max
 
 ### DashScope API Key
 
-Required for most commands. Get your key from the [DashScope Console](https://bailian.console.aliyun.com/cli?source_channel=key_github&).
+Required for most commands. Get your key from the [DashScope Console](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key).
 
 ```bash
 # Option 1: Environment variable
@@ -177,7 +177,7 @@ Config file location: `~/.bailian/config.json`
 | DashScope API Docs           | https://help.aliyun.com/zh/model-studio/                          |
 | Qwen Model List              | https://help.aliyun.com/zh/model-studio/getting-started/models    |
 | Aliyun Model Studio Console  | https://bailian.console.aliyun.com/                               |
-| Get API Key                  | https://bailian.console.aliyun.com/cli?source_channel=key_github& |
+| Get API Key                  | https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key |
 | Get AccessKey                | https://ram.console.aliyun.com/manage/ak                          |
 
 ## Changelog

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-[阿里云百炼 CLI 官方主页](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [English](https://github.com/modelstudioai/cli/blob/main/README.md) · [API 文档](https://help.aliyun.com/zh/model-studio/) · [获取 API Key](https://bailian.console.aliyun.com/cli?source_channel=key_github&)
+[阿里云百炼 CLI 官方主页](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [English](https://github.com/modelstudioai/cli/blob/main/README.md) · [API 文档](https://help.aliyun.com/zh/model-studio/) · [获取 API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ---
 
@@ -114,7 +114,7 @@ bl usage free --model qwen3-max
 
 ### DashScope API Key
 
-大部分命令均需要 API Key。前往 [DashScope 控制台](https://bailian.console.aliyun.com/cli?source_channel=key_github&) 获取。
+大部分命令均需要 API Key。前往 [DashScope 控制台](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key) 获取。
 
 ```bash
 # 方式一：环境变量
@@ -172,7 +172,7 @@ bl update
 | DashScope API 文档      | https://help.aliyun.com/zh/model-studio/                          |
 | 通义千问模型列表        | https://help.aliyun.com/zh/model-studio/getting-started/models    |
 | 阿里云百炼控制台        | https://bailian.console.aliyun.com/                               |
-| 获取 API Key            | https://bailian.console.aliyun.com/cli?source_channel=key_github& |
+| 获取 API Key            | https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key |
 | 获取 AccessKey          | https://ram.console.aliyun.com/manage/ak                          |
 
 ## 更新日志


### PR DESCRIPTION
## Summary

- Replace all API Key links from `/cli?source_channel=key_github&` to `/cn-beijing/?source_channel=key_github&tab=app#/api-key`
- Affects both README.md (EN) and README.zh.md (CN)
- Users now land directly on the API Key management page instead of the CLI homepage

## Changed

- 3 occurrences in README.md (top nav, auth section, links table)
- 3 occurrences in README.zh.md (same locations)