### PR TITLE
fix: add source_channel to console bare link in Links table

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Config file location: `~/.bailian/config.json`
 | Aliyun Model Studio CLI Site | https://bailian.console.aliyun.com/cli?source_channel=cli_github& |
 | DashScope API Docs           | https://help.aliyun.com/zh/model-studio/                          |
 | Qwen Model List              | https://help.aliyun.com/zh/model-studio/getting-started/models    |
-| Aliyun Model Studio Console  | https://bailian.console.aliyun.com/                               |
+| Aliyun Model Studio Console  | https://bailian.console.aliyun.com/?source_channel=cli_github                               |
 | Get API Key                  | https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key |
 | Get AccessKey                | https://ram.console.aliyun.com/manage/ak                          |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -171,7 +171,7 @@ bl update
 | 阿里云百炼 CLI 官方主页 | https://bailian.console.aliyun.com/cli?source_channel=cli_github& |
 | DashScope API 文档      | https://help.aliyun.com/zh/model-studio/                          |
 | 通义千问模型列表        | https://help.aliyun.com/zh/model-studio/getting-started/models    |
-| 阿里云百炼控制台        | https://bailian.console.aliyun.com/                               |
+| 阿里云百炼控制台        | https://bailian.console.aliyun.com/?source_channel=cli_github                               |
 | 获取 API Key            | https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key |
 | 获取 AccessKey          | https://ram.console.aliyun.com/manage/ak                          |
 


### PR DESCRIPTION
## Summary

Add `?source_channel=cli_github` to the bare Aliyun Model Studio Console link in the Links table (EN + CN).

This was missed in PR #41 which only targeted the API Key links.