### PR TITLE
fix(core): 修复 Rerank 字段类型用于请求体中

### DIFF
--- a/packages/cli/src/commands/knowledge/retrieve.ts
+++ b/packages/cli/src/commands/knowledge/retrieve.ts
@@ -220,7 +220,7 @@ async function runWithAkSk(
     };
     if (flags.rerankMode) rerank.RerankMode = flags.rerankMode as string;
     if (flags.rerankInstruct) rerank.RerankInstruct = flags.rerankInstruct as string;
-    body.Rerank = rerank;
+    body.Rerank = [rerank];
   }
 
   const pathname = `/${workspaceId}/index/retrieve`;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -363,11 +363,11 @@ export interface KnowledgeRetrieveRequest {
   EnableRewrite?: boolean;
   RerankTopN?: number;
   TopK?: number;
-  Rerank?: {
+  Rerank?: Array<{
     ModelName?: string;
     RerankMode?: string;
     RerankInstruct?: string;
-  };
+  }>;
   RerankTopN_legacy?: number;
   SearchFilters?: Array<{
     Key: string;


### PR DESCRIPTION
- 将 Rerank 字段从单对象修改为对象数组以支持多重重排序配置
- 更新 API 类型定义中 Rerank 为数组类型
- 修正 CLI 命令中构造请求体时将单一 Rerank 包装为数组
- 确保传递给后端的 Rerank 参数格式正确匹配接口要求