### PR TITLE
feat: No longer expose API documentation

### DIFF
--- a/docs/agents/branch-merge-review.md
+++ b/docs/agents/branch-merge-review.md
@@ -57,7 +57,7 @@ git diff --name-only <base>...<head>
 - [ ] **新命令 / 新 flag** 已同步到用户面文档:
   - [README.md](README.md) + [README.zh.md](README.zh.md)(中英文都要,常漏 `_CN`)
   - (SKILL.md 已迁出本仓库,由 `npx add skills` 机制独立维护,不在本仓库 review 范围)
-- [ ] **`bl <cmd> --help`** 文案完整:`description` / `examples` / `apiDocs` 都填了
+- [ ] **`bl <cmd> --help`** 文案完整:`description` / `examples` 都填了
 - [ ] **demo / quickstart**:用户可调用的新命令至少有一个示例
 - [ ] **行为变化的老命令**:在 commit message / CHANGELOG 注明用户感知的差异
 - [ ] **错误信息 / 提示文案**:面向用户的字符串通顺、双语(项目主体是中文场景)

--- a/docs/agents/command-add-remove.md
+++ b/docs/agents/command-add-remove.md
@@ -27,7 +27,7 @@
 命令元数据以 **`catalog.ts` 为单一登记处**;`registry.ts` 只负责解析与打印 help,不再内嵌命令表或手写 Resources 列表。
 
 ```
-commands/<...>.ts   defineCommand({ name, description, usage, options, examples, apiDocs?, run })
+commands/<...>.ts   defineCommand({ name, description, usage, options, examples, run })
         ↓
 commands/catalog.ts   export const commands: Record<string, Command>
         ↓
@@ -53,7 +53,6 @@ registry.ts  main.ts      tools/generate-reference.ts   export-schema.ts
   - 增删 `import xxx from "./.../xxx.ts"`
   - 在 `export const commands` 里增删 `"<group> <action>": xxx`(key 与 `defineCommand({ name })` 一致)
 - [ ] **不要**在 `registry.ts` 里重复登记命令(已从 catalog 读取)
-- [ ] 命令需在 `bl help` / `reference/` 展示 API 文档链接时,在 `defineCommand` 里设 `apiDocs`(相对路径);help 与 reference 均从此字段生成
 - [ ] 如果命令需要鉴权之外的特殊路径,看 `packages/cli/src/main.ts` 的 `NO_AUTH_SETUP`
 - [ ] **`config/export-schema.ts`**: 若新命令不适合作为 agent tool,评估是否加入 `SKIP_PREFIXES`;该文件在 `run()` 内 `import("../catalog.ts")`,勿顶层 import catalog 以免循环依赖
 

--- a/packages/cli/src/commands/file/upload.ts
+++ b/packages/cli/src/commands/file/upload.ts
@@ -12,7 +12,6 @@ import { emitResult, emitBare } from "../../output/output.ts";
 export default defineCommand({
   name: "file upload",
   description: "Upload a local file to DashScope temporary storage (48h)",
-  apiDocs: "/developer-reference/get-temporary-file-url",
   usage: "bl file upload --file <path> --model <model>",
   options: [
     {

--- a/packages/cli/src/commands/image/edit.ts
+++ b/packages/cli/src/commands/image/edit.ts
@@ -32,7 +32,6 @@ import {
 export default defineCommand({
   name: "image edit",
   description: "Edit an existing image with text instructions (Qwen-Image)",
-  apiDocs: "/developer-reference/qwen-image-edit-api",
   usage: "bl image edit --image <url> --prompt <text> [flags]",
   options: [
     {

--- a/packages/cli/src/commands/image/generate.ts
+++ b/packages/cli/src/commands/image/generate.ts
@@ -43,7 +43,6 @@ function isSyncModel(model: string): boolean {
 export default defineCommand({
   name: "image generate",
   description: "Generate images (Qwen-Image / wan2.x)",
-  apiDocs: "/best-practice/wanx/text-to-image",
   usage: "bl image generate --prompt <text> [flags]",
   options: [
     { flag: "--prompt <text>", description: "Image description", required: true },

--- a/packages/cli/src/commands/omni/chat.ts
+++ b/packages/cli/src/commands/omni/chat.ts
@@ -44,7 +44,6 @@ function buildWavHeader(dataLength: number): Buffer {
 export default defineCommand({
   name: "omni",
   description: "Multimodal chat with text + audio output (Qwen-Omni)",
-  apiDocs: "/model-studio/qwen-omni",
   usage: "bl omni --message <text> [flags]",
   options: [
     {

--- a/packages/cli/src/commands/speech/recognize.ts
+++ b/packages/cli/src/commands/speech/recognize.ts
@@ -25,7 +25,6 @@ import { emitResult, emitBare } from "../../output/output.ts";
 export default defineCommand({
   name: "speech recognize",
   description: "Recognize speech from audio files (FunAudio-ASR)",
-  apiDocs: "/developer-reference/recording-file-recognition",
   usage: "bl speech recognize --url <audio-url> [flags]",
   options: [
     {

--- a/packages/cli/src/commands/speech/synthesize.ts
+++ b/packages/cli/src/commands/speech/synthesize.ts
@@ -144,7 +144,6 @@ function printVoiceList(model: string): void {
 export default defineCommand({
   name: "speech synthesize",
   description: "Synthesize speech from text (CosyVoice TTS)",
-  apiDocs: "/developer-reference/cosyvoice",
   usage: "bl speech synthesize --text <text> [flags]",
   options: [
     { flag: "--text <text>", description: "Text to synthesize into speech", required: true },

--- a/packages/cli/src/commands/text/chat.ts
+++ b/packages/cli/src/commands/text/chat.ts
@@ -70,7 +70,6 @@ function parseMessages(flags: GlobalFlags): ParsedMessages {
 export default defineCommand({
   name: "text chat",
   description: "Send a chat completion (OpenAI compatible, DashScope)",
-  apiDocs: "/compatibility-of-openai-with-dashscope",
   usage: "bl text chat --message <text> [flags]",
   options: [
     { flag: "--model <model>", description: "Model ID (default: qwen3.7-max)" },

--- a/packages/cli/src/commands/video/edit.ts
+++ b/packages/cli/src/commands/video/edit.ts
@@ -31,7 +31,6 @@ export default defineCommand({
   name: "video edit",
   description:
     "Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)",
-  apiDocs: "/best-practice/wanx/video-edit",
   usage: "bl video edit --video <url> --prompt <text> [flags]",
   options: [
     { flag: "--model <model>", description: "Model ID (default: happyhorse-1.0-video-edit)" },

--- a/packages/cli/src/commands/video/generate.ts
+++ b/packages/cli/src/commands/video/generate.ts
@@ -44,7 +44,6 @@ export default defineCommand({
   name: "video generate",
   description:
     "Generate a video from text or image (happyhorse-1.0-t2v / happyhorse-1.0-i2v / wan2.6-t2v)",
-  apiDocs: "/best-practice/wanx/text-to-video",
   usage: "bl video generate --prompt <text> [--image <url>] [flags]",
   options: [
     {

--- a/packages/cli/src/commands/video/ref.ts
+++ b/packages/cli/src/commands/video/ref.ts
@@ -31,7 +31,6 @@ export default defineCommand({
   name: "video ref",
   description:
     "Reference-to-video generation (happyhorse-1.0-r2v / wan2.6-r2v): multi-subject, multi-shot with voice",
-  apiDocs: "/best-practice/wanx/video-reference",
   usage: "bl video ref --prompt <text> --image <url>... [--ref-video <url>...] [flags]",
   options: [
     { flag: "--model <model>", description: "Model ID (default: happyhorse-1.0-r2v)" },

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,11 +3,9 @@ import { registry } from "./registry.ts";
 import {
   GLOBAL_OPTIONS,
   loadConfig,
-  readConfigFile,
   resolveCredential,
   trackCommandExecution,
   flushTelemetry,
-  type Region,
 } from "bailian-cli-core";
 import { ensureApiKey } from "./utils/ensure-key.ts";
 import { handleError } from "./error-handler.ts";
@@ -22,13 +20,7 @@ import {
 } from "./utils/command-help.ts";
 
 registerCommandHelpPrinter((commandPath, out) => {
-  const a = process.argv.slice(2);
-  const ri = a.indexOf("--region");
-  const region = ((ri >= 0 && a[ri + 1]) ||
-    process.env.DASHSCOPE_REGION ||
-    readConfigFile().region ||
-    "cn") as Region;
-  registry.printHelp(commandPath, out, region);
+  registry.printHelp(commandPath, out);
 });
 
 // 优雅处理 Ctrl+C
@@ -84,12 +76,7 @@ async function main() {
   const commandPath = scanCommandPath(argv, GLOBAL_OPTIONS);
 
   if (argv.includes("--help") || argv.includes("-h")) {
-    const ri = argv.indexOf("--region");
-    const region = ((ri >= 0 && argv[ri + 1]) ||
-      process.env.DASHSCOPE_REGION ||
-      readConfigFile().region ||
-      "cn") as Region;
-    registry.printHelp(commandPath, process.stderr, region);
+    registry.printHelp(commandPath, process.stderr);
     process.exit(0);
   }
 
@@ -115,12 +102,7 @@ async function main() {
 
   // 组路径（例如 `bl speech` 未接子命令）：展示帮助后干净退出
   if (registry.isGroupPath(commandPath)) {
-    const ri = argv.indexOf("--region");
-    const region = ((ri >= 0 && argv[ri + 1]) ||
-      process.env.DASHSCOPE_REGION ||
-      readConfigFile().region ||
-      "cn") as Region;
-    registry.printHelp(commandPath, process.stderr, region);
+    registry.printHelp(commandPath, process.stderr);
     process.exit(0);
   }
 

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,7 +1,7 @@
 import type { Command } from "bailian-cli-core";
 import { BailianError } from "bailian-cli-core";
 import { ExitCode } from "bailian-cli-core";
-import { GLOBAL_OPTIONS, type Region } from "bailian-cli-core";
+import { GLOBAL_OPTIONS } from "bailian-cli-core";
 import { commands } from "./commands/catalog.ts";
 
 export type { Command, OptionDef } from "bailian-cli-core";
@@ -133,11 +133,7 @@ class CommandRegistry {
     out.isTTY ? `\x1b[38;2;59;130;246m${s}\x1b[0m` : s;
   private dim = (s: string, out: NodeJS.WriteStream) => (out.isTTY ? `\x1b[2m${s}\x1b[0m` : s);
 
-  printHelp(
-    commandPath: string[],
-    out: NodeJS.WriteStream = process.stdout,
-    region: Region = "cn",
-  ): void {
+  printHelp(commandPath: string[], out: NodeJS.WriteStream = process.stdout): void {
     if (commandPath.length === 0) {
       this.printRootHelp(out);
       return;
@@ -154,7 +150,7 @@ class CommandRegistry {
     }
 
     if (node.command) {
-      this.printCommandHelp(node.command, out, region);
+      this.printCommandHelp(node.command, out);
       return;
     }
 
@@ -233,7 +229,7 @@ ${b("Getting Help:")}
 `);
   }
 
-  private printCommandHelp(cmd: Command, out: NodeJS.WriteStream, region: Region = "cn"): void {
+  private printCommandHelp(cmd: Command, out: NodeJS.WriteStream): void {
     const b = (s: string) => this.bold(s, out);
     const a = (s: string) => this.accent(s, out);
     const d = (s: string) => this.dim(s, out);

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,7 +1,7 @@
 import type { Command } from "bailian-cli-core";
 import { BailianError } from "bailian-cli-core";
 import { ExitCode } from "bailian-cli-core";
-import { DOCS_HOSTS, GLOBAL_OPTIONS, type Region } from "bailian-cli-core";
+import { GLOBAL_OPTIONS, type Region } from "bailian-cli-core";
 import { commands } from "./commands/catalog.ts";
 
 export type { Command, OptionDef } from "bailian-cli-core";
@@ -252,9 +252,6 @@ ${b("Getting Help:")}
       for (const ex of cmd.examples) {
         out.write(`  ${d(ex)}\n`);
       }
-    }
-    if (cmd.apiDocs) {
-      out.write(`\n${b("API Reference:")} ${d(DOCS_HOSTS[region] + cmd.apiDocs)}\n`);
     }
     out.write(
       `\n${d("Global flags (--api-key, --output, --quiet, etc.) are always available.")}\n`,

--- a/packages/core/src/types/command.ts
+++ b/packages/core/src/types/command.ts
@@ -14,7 +14,6 @@ export interface Command {
   usage?: string;
   options?: OptionDef[];
   examples?: string[];
-  apiDocs?: string;
   execute: (config: Config, flags: GlobalFlags) => Promise<void>;
 }
 
@@ -24,7 +23,6 @@ export interface CommandSpec {
   usage?: string;
   options?: OptionDef[];
   examples?: string[];
-  apiDocs?: string;
   run: (config: Config, flags: GlobalFlags) => Promise<void>;
 }
 
@@ -35,7 +33,6 @@ export function defineCommand(spec: CommandSpec): Command {
     usage: spec.usage,
     options: spec.options,
     examples: spec.examples,
-    apiDocs: spec.apiDocs,
     execute: (config, flags) => spec.run(config, flags),
   };
 }

--- a/skills/bailian-cli/reference/file.md
+++ b/skills/bailian-cli/reference/file.md
@@ -15,12 +15,11 @@ Index: [index.md](index.md)
 
 ### `bl file upload`
 
-| Field           | Value                                                                                                                             |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `file upload`                                                                                                                     |
-| **Description** | Upload a local file to DashScope temporary storage (48h)                                                                          |
-| **Usage**       | `bl file upload --file <path> --model <model>`                                                                                    |
-| **API docs**    | [/developer-reference/get-temporary-file-url](https://help.aliyun.com/zh/model-studio/developer-reference/get-temporary-file-url) |
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| **Name**        | `file upload`                                            |
+| **Description** | Upload a local file to DashScope temporary storage (48h) |
+| **Usage**       | `bl file upload --file <path> --model <model>`           |
 
 #### Options
 

--- a/skills/bailian-cli/reference/image.md
+++ b/skills/bailian-cli/reference/image.md
@@ -16,12 +16,11 @@ Index: [index.md](index.md)
 
 ### `bl image edit`
 
-| Field           | Value                                                                                                                       |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `image edit`                                                                                                                |
-| **Description** | Edit an existing image with text instructions (Qwen-Image)                                                                  |
-| **Usage**       | `bl image edit --image <url> --prompt <text> [flags]`                                                                       |
-| **API docs**    | [/developer-reference/qwen-image-edit-api](https://help.aliyun.com/zh/model-studio/developer-reference/qwen-image-edit-api) |
+| Field           | Value                                                      |
+| --------------- | ---------------------------------------------------------- |
+| **Name**        | `image edit`                                               |
+| **Description** | Edit an existing image with text instructions (Qwen-Image) |
+| **Usage**       | `bl image edit --image <url> --prompt <text> [flags]`      |
 
 #### Options
 
@@ -63,12 +62,11 @@ bl image edit --image ./photo.png --prompt "把背景换成海滩" --watermark f
 
 ### `bl image generate`
 
-| Field           | Value                                                                                                         |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `image generate`                                                                                              |
-| **Description** | Generate images (Qwen-Image / wan2.x)                                                                         |
-| **Usage**       | `bl image generate --prompt <text> [flags]`                                                                   |
-| **API docs**    | [/best-practice/wanx/text-to-image](https://help.aliyun.com/zh/model-studio/best-practice/wanx/text-to-image) |
+| Field           | Value                                       |
+| --------------- | ------------------------------------------- |
+| **Name**        | `image generate`                            |
+| **Description** | Generate images (Qwen-Image / wan2.x)       |
+| **Usage**       | `bl image generate --prompt <text> [flags]` |
 
 #### Options
 

--- a/skills/bailian-cli/reference/omni.md
+++ b/skills/bailian-cli/reference/omni.md
@@ -15,12 +15,11 @@ Index: [index.md](index.md)
 
 ### `bl omni`
 
-| Field           | Value                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| **Name**        | `omni`                                                                                    |
-| **Description** | Multimodal chat with text + audio output (Qwen-Omni)                                      |
-| **Usage**       | `bl omni --message <text> [flags]`                                                        |
-| **API docs**    | [/model-studio/qwen-omni](https://help.aliyun.com/zh/model-studio/model-studio/qwen-omni) |
+| Field           | Value                                                |
+| --------------- | ---------------------------------------------------- |
+| **Name**        | `omni`                                               |
+| **Description** | Multimodal chat with text + audio output (Qwen-Omni) |
+| **Usage**       | `bl omni --message <text> [flags]`                   |
 
 #### Options
 

--- a/skills/bailian-cli/reference/speech.md
+++ b/skills/bailian-cli/reference/speech.md
@@ -16,12 +16,11 @@ Index: [index.md](index.md)
 
 ### `bl speech recognize`
 
-| Field           | Value                                                                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `speech recognize`                                                                                                                        |
-| **Description** | Recognize speech from audio files (FunAudio-ASR)                                                                                          |
-| **Usage**       | `bl speech recognize --url <audio-url> [flags]`                                                                                           |
-| **API docs**    | [/developer-reference/recording-file-recognition](https://help.aliyun.com/zh/model-studio/developer-reference/recording-file-recognition) |
+| Field           | Value                                            |
+| --------------- | ------------------------------------------------ |
+| **Name**        | `speech recognize`                               |
+| **Description** | Recognize speech from audio files (FunAudio-ASR) |
+| **Usage**       | `bl speech recognize --url <audio-url> [flags]`  |
 
 #### Options
 
@@ -70,12 +69,11 @@ bl speech recognize --url https://example.com/audio.mp3 --no-wait --quiet
 
 ### `bl speech synthesize`
 
-| Field           | Value                                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Name**        | `speech synthesize`                                                                                     |
-| **Description** | Synthesize speech from text (CosyVoice TTS)                                                             |
-| **Usage**       | `bl speech synthesize --text <text> [flags]`                                                            |
-| **API docs**    | [/developer-reference/cosyvoice](https://help.aliyun.com/zh/model-studio/developer-reference/cosyvoice) |
+| Field           | Value                                        |
+| --------------- | -------------------------------------------- |
+| **Name**        | `speech synthesize`                          |
+| **Description** | Synthesize speech from text (CosyVoice TTS)  |
+| **Usage**       | `bl speech synthesize --text <text> [flags]` |
 
 #### Options
 

--- a/skills/bailian-cli/reference/text.md
+++ b/skills/bailian-cli/reference/text.md
@@ -15,12 +15,11 @@ Index: [index.md](index.md)
 
 ### `bl text chat`
 
-| Field           | Value                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `text chat`                                                                                                               |
-| **Description** | Send a chat completion (OpenAI compatible, DashScope)                                                                     |
-| **Usage**       | `bl text chat --message <text> [flags]`                                                                                   |
-| **API docs**    | [/compatibility-of-openai-with-dashscope](https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope) |
+| Field           | Value                                                 |
+| --------------- | ----------------------------------------------------- |
+| **Name**        | `text chat`                                           |
+| **Description** | Send a chat completion (OpenAI compatible, DashScope) |
+| **Usage**       | `bl text chat --message <text> [flags]`               |
 
 #### Options
 

--- a/skills/bailian-cli/reference/video.md
+++ b/skills/bailian-cli/reference/video.md
@@ -44,12 +44,11 @@ bl video download --task-id 3b256896-xxxx --out video.mp4 --quiet
 
 ### `bl video edit`
 
-| Field           | Value                                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------- |
-| **Name**        | `video edit`                                                                                            |
-| **Description** | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)                  |
-| **Usage**       | `bl video edit --video <url> --prompt <text> [flags]`                                                   |
-| **API docs**    | [/best-practice/wanx/video-edit](https://help.aliyun.com/zh/model-studio/best-practice/wanx/video-edit) |
+| Field           | Value                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------- |
+| **Name**        | `video edit`                                                                           |
+| **Description** | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.) |
+| **Usage**       | `bl video edit --video <url> --prompt <text> [flags]`                                  |
 
 #### Options
 
@@ -92,12 +91,11 @@ bl video edit --video https://example.com/input.mp4 --prompt "给视频里的小
 
 ### `bl video generate`
 
-| Field           | Value                                                                                                         |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `video generate`                                                                                              |
-| **Description** | Generate a video from text or image (happyhorse-1.0-t2v / happyhorse-1.0-i2v / wan2.6-t2v)                    |
-| **Usage**       | `bl video generate --prompt <text> [--image <url>] [flags]`                                                   |
-| **API docs**    | [/best-practice/wanx/text-to-video](https://help.aliyun.com/zh/model-studio/best-practice/wanx/text-to-video) |
+| Field           | Value                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| **Name**        | `video generate`                                                                           |
+| **Description** | Generate a video from text or image (happyhorse-1.0-t2v / happyhorse-1.0-i2v / wan2.6-t2v) |
+| **Usage**       | `bl video generate --prompt <text> [--image <url>] [flags]`                                |
 
 #### Options
 
@@ -142,12 +140,11 @@ bl video generate --prompt "A cat playing with a ball" --watermark false
 
 ### `bl video ref`
 
-| Field           | Value                                                                                                             |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `video ref`                                                                                                       |
-| **Description** | Reference-to-video generation (happyhorse-1.0-r2v / wan2.6-r2v): multi-subject, multi-shot with voice             |
-| **Usage**       | `bl video ref --prompt <text> --image <url>... [--ref-video <url>...] [flags]`                                    |
-| **API docs**    | [/best-practice/wanx/video-reference](https://help.aliyun.com/zh/model-studio/best-practice/wanx/video-reference) |
+| Field           | Value                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| **Name**        | `video ref`                                                                                           |
+| **Description** | Reference-to-video generation (happyhorse-1.0-r2v / wan2.6-r2v): multi-subject, multi-shot with voice |
+| **Usage**       | `bl video ref --prompt <text> --image <url>... [--ref-video <url>...] [flags]`                        |
 
 #### Options
 

--- a/tools/generate-reference.ts
+++ b/tools/generate-reference.ts
@@ -11,12 +11,7 @@
 import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  DOCS_HOSTS,
-  GLOBAL_OPTIONS,
-  type Command,
-  type OptionDef,
-} from "../packages/core/dist/index.mjs";
+import { GLOBAL_OPTIONS, type Command, type OptionDef } from "../packages/core/dist/index.mjs";
 import { commands } from "../packages/cli/src/commands/catalog.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -68,10 +63,6 @@ function commandSection(path: string, cmd: Command): string {
   lines.push(`| **Description** | ${escCell(cmd.description)} |`);
   if (cmd.usage) {
     lines.push(`| **Usage** | \`${escCell(cmd.usage)}\` |`);
-  }
-  if (cmd.apiDocs) {
-    const url = `${DOCS_HOSTS.cn}${cmd.apiDocs}`;
-    lines.push(`| **API docs** | [${escCell(cmd.apiDocs)}](${url}) |`);
   }
   lines.push("");
 


### PR DESCRIPTION
## 背景

客户工单反馈（UID 1281942809114585）：bailian-cli skill 的 reference md（如 video.md）中 **API docs** 链接全部失效。排查确认 10 个 `apiDocs` 链接中 9 个已 404——这些路径基于帮助中心旧目录结构（`/best-practice/wanx/...`、`/developer-reference/...`），文档站改版后 slug 全部变更。且帮助中心对失效页返回 HTTP 200 + "404错误页" 软 404，普通链接巡检发现不了。

考虑到 CLI 的全部能力都通过命令本身提供，skill 的读者是 agent、并不需要跳转 API 文档（失效链接反而会诱导 agent 去 fetch 404 页面），决定整体移除 `apiDocs` 机制而非逐个修链接，从根上消除这类维护负担。

## 变更内容

- 删除 10 个命令定义中的 `apiDocs` 字段，及 `Command`/`CommandSpec` 类型中的声明
- `bl <cmd> --help` 不再打印 "API Reference" 行（registry.ts）
- `generate-reference.ts` 不再生成 "API docs" 表行，`skills/bailian-cli/reference/*.md` 已重新生成
- 同步更新 `docs/agents/` 两份 checklist
- 追加 commit：清理 help 打印链路中遗留的 `region` 死参数（其唯一用途是拼 `DOCS_HOSTS[region]` 前缀；且 `DOCS_HOSTS` 三个 region 的值本就相同，从未实际区分过）。API 接入点选择（loader.ts 的 `REGIONS`）不受影响

## 保留项

- `speech synthesize` 缺 `--voice` 报错中的 CosyVoice 音色复刻指引链接（synthesize.ts 的 `COSYVOICE_CLONE_DESIGN_DOC`）：属于操作必需指引而非 API 文档，已验证链接有效

## 后续

合并后需让 skill 分发渠道（`npx skills add modelstudioai/cli`）同步新的 reference md，客户工单方可闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)