### PR TITLE
refactor: infer flags type from options definition in defineCommand

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -147,14 +147,12 @@ export function parseFlags(argv: string[], options: OptionDef[]): GlobalFlags {
         );
       }
 
-      // Switch-style flags (--quiet, --dry-run): no value. Value flags need a non-flag next token.
       if (schema.booleans.has(camelKey)) {
         (flags as Record<string, unknown>)[camelKey] = true;
         i++;
         continue;
       }
 
-      // --prompt <text>, --watermark <bool>, …
       if (value === undefined) {
         i++;
         const next = argv[i];

--- a/packages/cli/src/commands/advisor/recommend.ts
+++ b/packages/cli/src/commands/advisor/recommend.ts
@@ -1,11 +1,9 @@
 import {
   analyzeIntent,
   buildDocLink,
-  type Config,
   defineCommand,
   detectOutputFormat,
   type GetModelsOptions,
-  type GlobalFlags,
   getModels,
   type IntentProfile,
   isInteractive,
@@ -241,9 +239,9 @@ export default defineCommand({
     'bl advisor recommend --message "Long document summarization" --dry-run',
     "bl advisor recommend                                          # Interactive input",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const positional = ((flags as Record<string, unknown>)._positional as string[]) ?? [];
-    let userInput = (flags.message as string) || positional.join(" ");
+    let userInput = flags.message || positional.join(" ");
 
     if (!userInput.trim()) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {

--- a/packages/cli/src/commands/app/call.ts
+++ b/packages/cli/src/commands/app/call.ts
@@ -5,8 +5,6 @@ import {
   appCompletionEndpoint,
   parseSSE,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type AppCompletionRequest,
   type AppStreamChunk,
   type AppCompletionResponse,
@@ -42,11 +40,11 @@ export default defineCommand({
     'bl app call --app-id abc123 --prompt "搜索资料" --pipeline-ids pipe1,pipe2',
     'bl app call --app-id abc123 --prompt "开始" --biz-params \'{"key":"value"}\'',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const appId = flags.appId as string;
+  async run(config, flags) {
+    const appId = flags.appId;
     if (!appId) failIfMissing("app-id", "bl app call --app-id <id> --prompt <text>");
 
-    const prompt = flags.prompt as string;
+    const prompt = flags.prompt;
     if (!prompt) failIfMissing("prompt", "bl app call --app-id <id> --prompt <text>");
 
     const shouldStream =
@@ -61,17 +59,17 @@ export default defineCommand({
     };
 
     if (flags.sessionId) {
-      body.input.session_id = flags.sessionId as string;
+      body.input.session_id = flags.sessionId;
     }
 
     // Pass image URLs via image_list
-    const imageUrls = flags.image as string[] | undefined;
+    const imageUrls = flags.image;
     if (imageUrls && imageUrls.length > 0) {
       body.input.image_list = imageUrls;
     }
 
     // Pass pre-uploaded file IDs
-    const fileIds = flags.fileId as string[] | undefined;
+    const fileIds = flags.fileId;
     if (fileIds && fileIds.length > 0) {
       body.input.file_ids = fileIds;
     }
@@ -81,7 +79,7 @@ export default defineCommand({
     }
 
     if (flags.pipelineIds) {
-      const ids = (flags.pipelineIds as string)
+      const ids = flags.pipelineIds
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean);
@@ -89,12 +87,12 @@ export default defineCommand({
     }
 
     if (flags.memoryId) {
-      body.parameters!.memory_id = flags.memoryId as string;
+      body.parameters!.memory_id = flags.memoryId;
     }
 
     if (flags.bizParams) {
       try {
-        body.input.biz_params = JSON.parse(flags.bizParams as string);
+        body.input.biz_params = JSON.parse(flags.bizParams);
       } catch {
         process.stderr.write("Error: --biz-params must be valid JSON\n");
         process.exit(1);

--- a/packages/cli/src/commands/app/list.ts
+++ b/packages/cli/src/commands/app/list.ts
@@ -3,8 +3,6 @@ import {
   callConsoleGateway,
   resolveConsoleGatewayCredential,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 
@@ -46,10 +44,10 @@ export default defineCommand({
     "bl app list --page 2 --page-size 10",
     "bl app list --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const name = (flags.name as string) || "";
-    const pageNo = (flags.page as number) || 1;
-    const pageSize = (flags.pageSize as number) || 30;
+  async run(config, flags) {
+    const name = flags.name || "";
+    const pageNo = flags.page || 1;
+    const pageSize = flags.pageSize || 30;
     const format = detectOutputFormat(config.output);
 
     const credential = await resolveConsoleGatewayCredential(config);

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -4,8 +4,6 @@ import {
   maskToken,
   readConfigFile,
   writeConfigFile,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { printQuickStart } from "../../output/banner.ts";
 import { emitBare } from "../../output/output.ts";
@@ -34,7 +32,7 @@ export default defineCommand({
     },
   ],
   examples: ["bl auth login --api-key sk-xxxxx", "bl auth login --console"],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     if (flags.console) {
       if (config.dryRun) {
         emitBare(
@@ -66,13 +64,13 @@ export default defineCommand({
       }
     }
 
-    const key = (flags.apiKey as string) || config.apiKey;
+    const key = flags.apiKey || config.apiKey;
     if (!key) {
       printCurrentCommandHelp(process.stderr);
       process.exit(0);
     }
 
-    const baseUrl = (flags.baseUrl as string) || undefined;
+    const baseUrl = flags.baseUrl || undefined;
     const effectiveConfig = baseUrl ? { ...config, baseUrl } : config;
 
     if (!config.dryRun) {

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -4,8 +4,6 @@ import {
   readConfigFile,
   writeConfigFile,
   getConfigPath,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitBare } from "../../output/output.ts";
 
@@ -35,7 +33,7 @@ export default defineCommand({
     "bl auth logout --dry-run",
     "bl auth logout --yes",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const file = readConfigFile();
 
     if (flags.console) {

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -5,7 +5,6 @@ import {
   detectOutputFormat,
   maskToken,
   type Config,
-  type GlobalFlags,
   type ResolvedCredential,
 } from "bailian-cli-core";
 import { emitResult, emitBare } from "../../output/output.ts";
@@ -155,7 +154,7 @@ export default defineCommand({
     },
   ],
   examples: ["bl auth status", "bl auth status --output json"],
-  async run(config: Config, _flags: GlobalFlags) {
+  async run(config, _flags) {
     const format = detectOutputFormat(config.output);
     const status = await buildStatus(config);
 

--- a/packages/cli/src/commands/config/export-schema.ts
+++ b/packages/cli/src/commands/config/export-schema.ts
@@ -1,6 +1,4 @@
 import { defineCommand, generateToolSchema } from "bailian-cli-core";
-import type { Config } from "bailian-cli-core";
-import type { GlobalFlags } from "bailian-cli-core";
 import { BailianError } from "bailian-cli-core";
 import { ExitCode } from "bailian-cli-core";
 
@@ -21,9 +19,9 @@ export default defineCommand({
     },
   ],
   examples: ["bl config export-schema", 'bl config export-schema --command "video generate"'],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const { commands } = await import("../catalog.ts");
-    const targetCommand = flags.command as string | undefined;
+    const targetCommand = flags.command;
 
     if (targetCommand) {
       const command = commands[targetCommand];

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -5,8 +5,6 @@ import {
   readConfigFile,
   writeConfigFile,
   BailianError,
-  type Config,
-  type GlobalFlags,
   ExitCode,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
@@ -67,9 +65,9 @@ export default defineCommand({
     "bl config set --key timeout --value 600",
     "bl config set --key base_url --value https://dashscope.aliyuncs.com",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const key = flags.key as string | undefined;
-    const value = flags.value as string | undefined;
+  async run(config, flags) {
+    const key = flags.key;
+    const value = flags.value;
 
     if (!key || value === undefined) {
       throw new BailianError(

--- a/packages/cli/src/commands/config/show.ts
+++ b/packages/cli/src/commands/config/show.ts
@@ -4,8 +4,6 @@ import {
   getConfigPath,
   detectOutputFormat,
   maskToken,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 
@@ -14,7 +12,7 @@ export default defineCommand({
   description: "Display current configuration",
   usage: "bl config show",
   examples: ["bl config show", "bl config show --output json"],
-  async run(config: Config, _flags: GlobalFlags) {
+  async run(config, _flags) {
     const file = loadConfigFile();
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/console/call.ts
+++ b/packages/cli/src/commands/console/call.ts
@@ -6,8 +6,6 @@ import {
   CONSOLE_GATEWAY_NO_TOKEN_MESSAGE,
   BailianError,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
 import { emitResult } from "../../output/output.ts";
@@ -42,11 +40,11 @@ export default defineCommand({
     `bl console call --api zeldaEasy.broadscope-bailian.freeTrial.queryFreeTierQuota --data '{"queryFreeTierQuotaRequest":{"models":["qwen3-max"]}}'`,
     `bl console call --api some.api.name --data '{"key":"value"}' --console-region cn-beijing`,
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const api = flags.api as string;
+  async run(config, flags) {
+    const api = flags.api;
     if (!api) failIfMissing("api", "bl console call --api <api> --data <json>");
 
-    const dataRaw = flags.data as string;
+    const dataRaw = flags.data;
     if (!dataRaw) failIfMissing("data", "bl console call --api <api> --data <json>");
 
     let data: Record<string, unknown>;

--- a/packages/cli/src/commands/file/upload.ts
+++ b/packages/cli/src/commands/file/upload.ts
@@ -1,11 +1,4 @@
-import {
-  defineCommand,
-  resolveCredential,
-  detectOutputFormat,
-  type Config,
-  type GlobalFlags,
-  uploadFile,
-} from "bailian-cli-core";
+import { defineCommand, resolveCredential, detectOutputFormat, uploadFile } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
 import { emitResult, emitBare } from "../../output/output.ts";
 
@@ -31,13 +24,13 @@ export default defineCommand({
     "bl file upload --file audio.wav --model qwen3-asr-flash",
     "bl file upload --file cat.png --model qwen-image-2.0",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const filePath = flags.file as string | undefined;
+  async run(config, flags) {
+    const filePath = flags.file;
     if (!filePath) {
       failIfMissing("file", "bl file upload --file <path> --model <model>");
     }
 
-    const model = flags.model as string | undefined;
+    const model = flags.model;
     if (!model) {
       failIfMissing("model", "bl file upload --file <path> --model <model>");
     }

--- a/packages/cli/src/commands/image/edit.ts
+++ b/packages/cli/src/commands/image/edit.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   imageSyncEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   resolveCredential,
   resolveFileUrl,
   resolveOutputDir,
@@ -70,11 +68,11 @@ export default defineCommand({
     'bl image edit --image https://example.com/photo.png --prompt "Remove the person" --model qwen-image-2.0-pro',
     'bl image edit --image ./photo.png --prompt "把背景换成海滩" --watermark false',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     // Normalize --image to string array (supports both single and repeated flags)
     let rawImages: string[] = [];
     if (Array.isArray(flags.image)) {
-      rawImages = flags.image as string[];
+      rawImages = flags.image;
     } else if (typeof flags.image === "string") {
       rawImages = [flags.image];
     }
@@ -82,7 +80,7 @@ export default defineCommand({
       failIfMissing("image", "bl image edit --image <url> --prompt <text>");
     }
 
-    let prompt = flags.prompt as string | undefined;
+    let prompt = flags.prompt;
     if (!prompt) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({
@@ -98,14 +96,14 @@ export default defineCommand({
       }
     }
 
-    const model = (flags.model as string) || config.defaultImageModel || "qwen-image-2.0";
+    const model = flags.model || config.defaultImageModel || "qwen-image-2.0";
 
     // Auto-upload local files (resolve all images in parallel)
     const credential = await resolveCredential(config);
     const resolvedImages = await Promise.all(
       rawImages.map((img) => resolveFileUrl(img, credential.token, model)),
     );
-    const n = (flags.n as number) ?? 1;
+    const n = flags.n ?? 1;
 
     const promptExtend = resolveBooleanFlag(flags.promptExtend, true, "prompt-extend");
 
@@ -128,12 +126,12 @@ export default defineCommand({
         ],
       },
       parameters: {
-        size: resolveImageSize(flags.size as string | undefined, true),
+        size: resolveImageSize(flags.size, true),
         n,
-        seed: flags.seed as number | undefined,
+        seed: flags.seed,
         prompt_extend: promptExtend,
         watermark,
-        negative_prompt: (flags.negativePrompt as string) || undefined,
+        negative_prompt: flags.negativePrompt || undefined,
       },
     };
 
@@ -174,12 +172,11 @@ export default defineCommand({
     }
 
     const outDir = resolveOutputDir(config, {
-      flagDir: flags.outDir as string | undefined,
+      flagDir: flags.outDir,
       subDir: flags.outDir ? undefined : "images",
     });
 
-    const prefix =
-      (flags.outPrefix as string) || generateFilename("edited", flags?.prompt as string);
+    const prefix = flags.outPrefix || generateFilename("edited", flags.prompt as string);
 
     // Parallel download all images
     const items =

--- a/packages/cli/src/commands/image/generate.ts
+++ b/packages/cli/src/commands/image/generate.ts
@@ -92,10 +92,8 @@ export default defineCommand({
     'bl image generate --prompt "Pro quality" --model qwen-image-2.0-pro',
     'bl image generate --prompt "Product shots" --n 2 --concurrent 3  # 6 images in parallel',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    let prompt = (flags.prompt ?? (flags._positional as string[] | undefined)?.[0]) as
-      | string
-      | undefined;
+  async run(config, flags) {
+    let prompt = flags.prompt ?? (flags._positional as string[] | undefined)?.[0];
 
     if (!prompt) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
@@ -112,12 +110,12 @@ export default defineCommand({
       }
     }
 
-    const model = (flags.model as string) || config.defaultImageModel || "qwen-image-2.0";
+    const model = flags.model || config.defaultImageModel || "qwen-image-2.0";
     const useSync = isSyncModel(model);
     const defaultSize = useSync ? "1:1" : "1:1";
-    const sizeInput = (flags.size as string) || defaultSize;
+    const sizeInput = flags.size || defaultSize;
     const size = resolveImageSize(sizeInput, useSync);
-    const n = (flags.n as number) ?? 1;
+    const n = flags.n ?? 1;
     const concurrent = getConcurrency(flags);
 
     const promptExtend = resolveBooleanFlag(
@@ -136,10 +134,10 @@ export default defineCommand({
       parameters: {
         size,
         n,
-        seed: flags.seed as number | undefined,
+        seed: flags.seed,
         prompt_extend: promptExtend,
         watermark,
-        negative_prompt: (flags.negativePrompt as string) || undefined,
+        negative_prompt: flags.negativePrompt || undefined,
       },
     };
 

--- a/packages/cli/src/commands/knowledge/retrieve.ts
+++ b/packages/cli/src/commands/knowledge/retrieve.ts
@@ -72,11 +72,11 @@ export default defineCommand({
     'bl knowledge retrieve --index-id idx_xxx --query "如何使用阿里云百炼"',
     'bl knowledge retrieve --index-id idx_xxx --query "API限流" --rerank --rerank-model qwen3-rerank-hybrid',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const indexId = flags.indexId as string;
+  async run(config, flags) {
+    const indexId = flags.indexId;
     if (!indexId) failIfMissing("index-id", "bl knowledge retrieve --index-id <id> --query <text>");
 
-    const query = flags.query as string;
+    const query = flags.query;
     if (!query) failIfMissing("query", "bl knowledge retrieve --index-id <id> --query <text>");
 
     const format = detectOutputFormat(config.output);

--- a/packages/cli/src/commands/mcp/call.ts
+++ b/packages/cli/src/commands/mcp/call.ts
@@ -1,11 +1,4 @@
-import {
-  defineCommand,
-  McpClient,
-  bailianMcpUrl,
-  detectOutputFormat,
-  type Config,
-  type GlobalFlags,
-} from "bailian-cli-core";
+import { defineCommand, McpClient, bailianMcpUrl, detectOutputFormat } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
 import { emitResult } from "../../output/output.ts";
 import { ensureApiKey } from "../../utils/ensure-key.ts";
@@ -60,7 +53,7 @@ export default defineCommand({
     'bl mcp call market-cmapi00073529.FinQuery --json \'{"q":"贵州茅台","limit":5}\'',
     "bl mcp call market-cmapi00073529.SmartFundSelection --arg riskLevel=R3 --arg minScale=10",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const positional =
       ((flags as Record<string, unknown>)._positional as string[] | undefined) ?? [];
     const target = positional[0];
@@ -77,7 +70,7 @@ export default defineCommand({
     let toolArgs: Record<string, unknown> = {};
     if (flags.json) {
       try {
-        const parsed = JSON.parse(flags.json as string);
+        const parsed = JSON.parse(flags.json);
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
           process.stderr.write("Error: --json must decode to an object.\n");
           process.exit(1);
@@ -88,10 +81,10 @@ export default defineCommand({
         process.exit(1);
       }
     }
-    Object.assign(toolArgs, parseArgFlags((flags.arg as string[] | undefined) ?? []));
+    Object.assign(toolArgs, parseArgFlags(flags.arg ?? []));
     if (flags.query !== undefined) toolArgs.query = flags.query;
 
-    const url = (flags.url as string) || bailianMcpUrl(config.baseUrl, serverCode);
+    const url = flags.url || bailianMcpUrl(config.baseUrl, serverCode);
     const format = detectOutputFormat(config.output);
 
     if (config.dryRun) {

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -6,8 +6,6 @@ import {
   detectOutputFormat,
   BailianError,
   ExitCode,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 
@@ -48,11 +46,11 @@ export default defineCommand({
     },
   ],
   examples: ["bl mcp list", "bl mcp list --name 金融", "bl mcp list --output json"],
-  async run(config: Config, flags: GlobalFlags) {
-    const serverName = (flags.name as string) || "";
-    const type = (flags.type as string) || "OFFICIAL";
-    const pageNo = (flags.page as number) || 1;
-    const pageSize = (flags.pageSize as number) || 30;
+  async run(config, flags) {
+    const serverName = flags.name || "";
+    const type = flags.type || "OFFICIAL";
+    const pageNo = flags.page || 1;
+    const pageSize = flags.pageSize || 30;
     const format = detectOutputFormat(config.output);
 
     const data = {

--- a/packages/cli/src/commands/mcp/tools.ts
+++ b/packages/cli/src/commands/mcp/tools.ts
@@ -1,11 +1,4 @@
-import {
-  defineCommand,
-  McpClient,
-  bailianMcpUrl,
-  detectOutputFormat,
-  type Config,
-  type GlobalFlags,
-} from "bailian-cli-core";
+import { defineCommand, McpClient, bailianMcpUrl, detectOutputFormat } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
 import { emitResult } from "../../output/output.ts";
 import { ensureApiKey } from "../../utils/ensure-key.ts";
@@ -27,13 +20,13 @@ export default defineCommand({
     "bl mcp tools market-cmapi00073529 --output json",
     "bl mcp tools my-server --url https://example.com/mcp",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const positional =
       ((flags as Record<string, unknown>)._positional as string[] | undefined) ?? [];
     const code = positional[0];
     if (!code) failIfMissing("server-code", "bl mcp tools <server-code>");
 
-    const url = (flags.url as string) || bailianMcpUrl(config.baseUrl, code!);
+    const url = flags.url || bailianMcpUrl(config.baseUrl, code!);
     const format = detectOutputFormat(config.output);
 
     if (config.dryRun) {

--- a/packages/cli/src/commands/memory/add.ts
+++ b/packages/cli/src/commands/memory/add.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   memoryAddEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type MemoryAddRequest,
   type MemoryAddResponse,
 } from "bailian-cli-core";
@@ -30,15 +28,15 @@ export default defineCommand({
     'bl memory add --user-id user1 --messages \'[{"role":"user","content":"我喜欢旅行"}]\'',
     'bl memory add --user-id user1 --content "住在北京" --profile-schema schema_xxx',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const userId = flags.userId as string;
+  async run(config, flags) {
+    const userId = flags.userId;
     if (!userId) failIfMissing("user-id", "bl memory add --user-id <id>");
 
     const body: MemoryAddRequest = { user_id: userId };
 
     if (flags.messages) {
       try {
-        body.messages = JSON.parse(flags.messages as string);
+        body.messages = JSON.parse(flags.messages);
       } catch {
         process.stderr.write("Error: --messages must be valid JSON array\n");
         process.exit(1);
@@ -46,7 +44,7 @@ export default defineCommand({
     }
 
     if (flags.content) {
-      body.custom_content = flags.content as string;
+      body.custom_content = flags.content;
     }
 
     if (!body.messages && !body.custom_content) {
@@ -54,8 +52,8 @@ export default defineCommand({
       process.exit(1);
     }
 
-    if (flags.profileSchema) body.profile_schema = flags.profileSchema as string;
-    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId as string;
+    if (flags.profileSchema) body.profile_schema = flags.profileSchema;
+    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId;
 
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/memory/delete.ts
+++ b/packages/cli/src/commands/memory/delete.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   memoryNodeEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
 import { emitResult, emitBare } from "../../output/output.ts";
@@ -19,16 +17,16 @@ export default defineCommand({
     { flag: "--memory-library-id <id>", description: "Memory library ID (non-default library)" },
   ],
   examples: ["bl memory delete --node-id node_xxx --user-id user1"],
-  async run(config: Config, flags: GlobalFlags) {
-    const nodeId = flags.nodeId as string;
+  async run(config, flags) {
+    const nodeId = flags.nodeId;
     if (!nodeId) failIfMissing("node-id", "bl memory delete --node-id <id> --user-id <id>");
 
-    const userId = flags.userId as string;
+    const userId = flags.userId;
     if (!userId) failIfMissing("user-id", "bl memory delete --node-id <id> --user-id <id>");
 
     const format = detectOutputFormat(config.output);
     const params = new URLSearchParams({ user_id: userId });
-    if (flags.memoryLibraryId) params.set("memory_library_id", flags.memoryLibraryId as string);
+    if (flags.memoryLibraryId) params.set("memory_library_id", flags.memoryLibraryId);
     const url = `${memoryNodeEndpoint(config.baseUrl, nodeId)}?${params.toString()}`;
 
     if (config.dryRun) {

--- a/packages/cli/src/commands/memory/list.ts
+++ b/packages/cli/src/commands/memory/list.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   memoryListEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type MemoryNodeListResponse,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
@@ -24,16 +22,16 @@ export default defineCommand({
     "bl memory list --user-id user1",
     "bl memory list --user-id user1 --page-size 20 --page 2",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const userId = flags.userId as string;
+  async run(config, flags) {
+    const userId = flags.userId;
     if (!userId) failIfMissing("user-id", "bl memory list --user-id <id>");
 
     const format = detectOutputFormat(config.output);
     const params = new URLSearchParams();
     params.set("user_id", userId);
-    if (flags.pageSize !== undefined) params.set("page_size", String(flags.pageSize as number));
-    if (flags.page !== undefined) params.set("page_num", String(flags.page as number));
-    if (flags.memoryLibraryId) params.set("memory_library_id", flags.memoryLibraryId as string);
+    if (flags.pageSize !== undefined) params.set("page_size", String(flags.pageSize));
+    if (flags.page !== undefined) params.set("page_num", String(flags.page));
+    if (flags.memoryLibraryId) params.set("memory_library_id", flags.memoryLibraryId);
 
     const url = `${memoryListEndpoint(config.baseUrl)}?${params.toString()}`;
 

--- a/packages/cli/src/commands/memory/profile-create.ts
+++ b/packages/cli/src/commands/memory/profile-create.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   profileSchemaEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type ProfileSchemaCreateRequest,
   type ProfileSchemaCreateResponse,
 } from "bailian-cli-core";
@@ -27,11 +25,11 @@ export default defineCommand({
   examples: [
     'bl memory profile create --name "user_basic" --attributes \'[{"name":"age","description":"年龄"},{"name":"hobby","description":"爱好"}]\'',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const name = flags.name as string;
+  async run(config, flags) {
+    const name = flags.name;
     if (!name) failIfMissing("name", "bl memory profile create --name <name> --attributes <json>");
 
-    const attrStr = flags.attributes as string;
+    const attrStr = flags.attributes;
     if (!attrStr)
       failIfMissing("attributes", "bl memory profile create --name <name> --attributes <json>");
 
@@ -44,7 +42,7 @@ export default defineCommand({
     }
 
     const body: ProfileSchemaCreateRequest = { name, attributes };
-    if (flags.description) body.description = flags.description as string;
+    if (flags.description) body.description = flags.description;
 
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/memory/profile-get.ts
+++ b/packages/cli/src/commands/memory/profile-get.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   userProfileEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type UserProfileResponse,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
@@ -19,12 +17,12 @@ export default defineCommand({
     { flag: "--user-id <id>", description: "User ID (required)", required: true },
   ],
   examples: ["bl memory profile get --schema-id schema_xxx --user-id user1"],
-  async run(config: Config, flags: GlobalFlags) {
-    const schemaId = flags.schemaId as string;
+  async run(config, flags) {
+    const schemaId = flags.schemaId;
     if (!schemaId)
       failIfMissing("schema-id", "bl memory profile get --schema-id <id> --user-id <id>");
 
-    const userId = flags.userId as string;
+    const userId = flags.userId;
     if (!userId) failIfMissing("user-id", "bl memory profile get --schema-id <id> --user-id <id>");
 
     const format = detectOutputFormat(config.output);

--- a/packages/cli/src/commands/memory/search.ts
+++ b/packages/cli/src/commands/memory/search.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   memorySearchEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type MemorySearchRequest,
   type MemorySearchResponse,
 } from "bailian-cli-core";
@@ -30,17 +28,17 @@ export default defineCommand({
     'bl memory search --user-id user1 --query "编程偏好"',
     'bl memory search --user-id user1 --messages \'[{"role":"user","content":"推荐一本书"}]\' --top-k 5',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const userId = flags.userId as string;
+  async run(config, flags) {
+    const userId = flags.userId;
     if (!userId) failIfMissing("user-id", "bl memory search --user-id <id>");
 
     const body: MemorySearchRequest = { user_id: userId };
 
-    if (flags.query) body.query = flags.query as string;
+    if (flags.query) body.query = flags.query;
 
     if (flags.messages) {
       try {
-        body.messages = JSON.parse(flags.messages as string);
+        body.messages = JSON.parse(flags.messages);
       } catch {
         process.stderr.write("Error: --messages must be valid JSON array\n");
         process.exit(1);
@@ -57,8 +55,8 @@ export default defineCommand({
       process.exit(1);
     }
 
-    if (flags.topK !== undefined) body.top_k = flags.topK as number;
-    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId as string;
+    if (flags.topK !== undefined) body.top_k = flags.topK;
+    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId;
 
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/memory/update.ts
+++ b/packages/cli/src/commands/memory/update.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   memoryNodeEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type MemoryNodeUpdateRequest,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
@@ -25,16 +23,16 @@ export default defineCommand({
     { flag: "--memory-library-id <id>", description: "Memory library ID (non-default library)" },
   ],
   examples: ['bl memory update --node-id node_xxx --user-id user1 --content "更新后的记忆内容"'],
-  async run(config: Config, flags: GlobalFlags) {
-    const nodeId = flags.nodeId as string;
+  async run(config, flags) {
+    const nodeId = flags.nodeId;
     if (!nodeId)
       failIfMissing("node-id", "bl memory update --node-id <id> --user-id <id> --content <text>");
 
-    const userId = flags.userId as string;
+    const userId = flags.userId;
     if (!userId)
       failIfMissing("user-id", "bl memory update --node-id <id> --user-id <id> --content <text>");
 
-    const content = flags.content as string;
+    const content = flags.content;
     if (!content)
       failIfMissing("content", "bl memory update --node-id <id> --user-id <id> --content <text>");
 
@@ -42,7 +40,7 @@ export default defineCommand({
       user_id: userId,
       custom_content: content,
     };
-    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId as string;
+    if (flags.memoryLibraryId) body.memory_library_id = flags.memoryLibraryId;
 
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/omni/chat.ts
+++ b/packages/cli/src/commands/omni/chat.ts
@@ -8,8 +8,6 @@ import {
   detectOutputFormat,
   BailianError,
   ExitCode,
-  type Config,
-  type GlobalFlags,
   type ChatMessage,
   type ChatMessageContent,
   type ChatRequest,
@@ -128,11 +126,11 @@ export default defineCommand({
     'bl omni --message "Hello" --text-only --output json',
     'bl omni --message "朗读这段话" --audio-out greeting.wav',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     // --- Parse messages ---
     let userMessages: string[] = [];
     if (flags.message) {
-      userMessages = flags.message as string[];
+      userMessages = flags.message;
     }
 
     if (userMessages.length === 0) {
@@ -148,16 +146,16 @@ export default defineCommand({
       }
     }
 
-    const model = (flags.model as string) || config.defaultOmniModel || "qwen3.5-omni-plus";
-    const voice = (flags.voice as string) || "Cherry";
-    const audioFormat = (flags.audioFormat as string) || "wav";
+    const model = flags.model || config.defaultOmniModel || "qwen3.5-omni-plus";
+    const voice = flags.voice || "Cherry";
+    const audioFormat = flags.audioFormat || "wav";
     const textOnly = flags.textOnly === true;
     const format = detectOutputFormat(config.output);
 
     // --- Build messages array ---
     const allMessages: ChatMessage[] = [];
     if (flags.system) {
-      allMessages.push({ role: "system", content: flags.system as string });
+      allMessages.push({ role: "system", content: flags.system });
     }
 
     // Build multimodal content for user messages
@@ -179,9 +177,9 @@ export default defineCommand({
     }
 
     // Attach multimodal inputs to the last user message
-    const rawImageUrls = (flags.image as string[] | undefined) || [];
-    const rawAudioUrls = (flags.audio as string[] | undefined) || [];
-    const rawVideoUrls = (flags.video as string[] | undefined) || [];
+    const rawImageUrls = flags.image || [];
+    const rawAudioUrls = flags.audio || [];
+    const rawVideoUrls = flags.video || [];
 
     // Auto-upload local files
     const imageUrls: string[] = [];
@@ -276,8 +274,8 @@ export default defineCommand({
       body.audio = { voice, format: audioFormat };
     }
 
-    if (flags.maxTokens !== undefined) body.max_tokens = flags.maxTokens as number;
-    if (flags.temperature !== undefined) body.temperature = flags.temperature as number;
+    if (flags.maxTokens !== undefined) body.max_tokens = flags.maxTokens;
+    if (flags.temperature !== undefined) body.temperature = flags.temperature;
 
     if (config.dryRun) {
       emitResult({ request: body }, format);
@@ -340,7 +338,7 @@ export default defineCommand({
       const wavHeader = buildWavHeader(pcmBuffer.length);
       const wavBuffer = Buffer.concat([wavHeader, pcmBuffer]);
 
-      let destPath = flags.audioOut as string | undefined;
+      let destPath = flags.audioOut;
       if (!destPath) {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const { join } = await import("path");

--- a/packages/cli/src/commands/pipeline/run.ts
+++ b/packages/cli/src/commands/pipeline/run.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { defineCommand, type Config, type GlobalFlags } from "bailian-cli-core";
+import { defineCommand, type GlobalFlags } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { initPipelineSteps } from "../../pipeline/init.ts";
 import { executePipeline, streamPipelineEvents } from "../../pipeline/executor.ts";
@@ -33,7 +33,7 @@ export default defineCommand({
     "bl pipeline run workflow.json --events jsonl",
     "bl pipeline run workflow.yaml --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const file = ((flags._positional as string[] | undefined) ?? [])[0] as string | undefined;
     if (!file) {
       process.stderr.write("Error: pipeline file is required\nUsage: bl pipeline run <file>\n");
@@ -42,7 +42,7 @@ export default defineCommand({
 
     initPipelineSteps();
 
-    const eventsFormat = flags.events as string | undefined;
+    const eventsFormat = flags.events;
     if (eventsFormat !== undefined && eventsFormat !== "jsonl") {
       process.stderr.write(
         `Error: unsupported --events format: ${eventsFormat}. Supported: jsonl\n`,
@@ -57,10 +57,10 @@ export default defineCommand({
 
     if (eventsFormat === "jsonl") {
       for await (const event of streamPipelineEvents(pipeline, runtimeInput, {
-        concurrency: flags.concurrency as number | undefined,
+        concurrency: flags.concurrency,
         basePath,
         dryRun: flags.dryRun,
-        timeoutSeconds: flags.timeout as number | undefined,
+        timeoutSeconds: flags.timeout,
       })) {
         process.stdout.write(JSON.stringify(event) + "\n");
       }
@@ -68,10 +68,10 @@ export default defineCommand({
     }
 
     const report = await executePipeline(pipeline, runtimeInput, {
-      concurrency: flags.concurrency as number | undefined,
+      concurrency: flags.concurrency,
       basePath,
       dryRun: flags.dryRun,
-      timeoutSeconds: flags.timeout as number | undefined,
+      timeoutSeconds: flags.timeout,
       onEvent: flags.verbose ? logEvent : undefined,
     });
 

--- a/packages/cli/src/commands/pipeline/validate.ts
+++ b/packages/cli/src/commands/pipeline/validate.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import { defineCommand, type Config, type GlobalFlags } from "bailian-cli-core";
+import { defineCommand } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { initPipelineSteps } from "../../pipeline/init.ts";
 import { collectPipelineIssues, collectPipelineHints } from "../../pipeline/validation.ts";
@@ -14,7 +14,7 @@ export default defineCommand({
     "bl pipeline validate workflow.yaml",
     "bl pipeline validate workflow.json --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const file = ((flags._positional as string[] | undefined) ?? [])[0] as string | undefined;
     if (!file) {
       process.stderr.write(

--- a/packages/cli/src/commands/quota/check.ts
+++ b/packages/cli/src/commands/quota/check.ts
@@ -5,7 +5,6 @@ import {
   resolveConsoleGatewayCredential,
   detectOutputFormat,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -272,8 +271,8 @@ export default defineCommand({
     "bl quota check --model qwen3.6-plus,qwen-turbo",
     "bl quota check --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelFlag = (flags.model as string) || undefined;
+  async run(config, flags) {
+    const modelFlag = flags.model || undefined;
     const rawPeriod = Number(flags.period) || 2;
     if (rawPeriod < 1) {
       process.stderr.write("Error: --period must be at least 1 minute.\n");

--- a/packages/cli/src/commands/quota/history.ts
+++ b/packages/cli/src/commands/quota/history.ts
@@ -4,8 +4,6 @@ import {
   resolveConsoleGatewayCredential,
   detectOutputFormat,
   BailianError,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -132,10 +130,10 @@ export default defineCommand({
     "bl quota history --model qwen-turbo",
     "bl quota history --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const page = Number(flags.page) || 1;
     const pageSize = Number(flags.pageSize) || 10;
-    const modelFilter = (flags.model as string) || undefined;
+    const modelFilter = flags.model || undefined;
     const format = detectOutputFormat(config.output);
 
     const credential = await resolveConsoleGatewayCredential(config);

--- a/packages/cli/src/commands/quota/list.ts
+++ b/packages/cli/src/commands/quota/list.ts
@@ -4,7 +4,6 @@ import {
   resolveConsoleGatewayCredential,
   detectOutputFormat,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -187,8 +186,8 @@ export default defineCommand({
     "bl quota list --all",
     "bl quota list --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelFlag = (flags.model as string) || undefined;
+  async run(config, flags) {
+    const modelFlag = flags.model || undefined;
     const showAll = Boolean(flags.all);
     const format = detectOutputFormat(config.output);
 

--- a/packages/cli/src/commands/quota/request.ts
+++ b/packages/cli/src/commands/quota/request.ts
@@ -5,7 +5,6 @@ import {
   detectOutputFormat,
   BailianError,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 
@@ -112,8 +111,8 @@ export default defineCommand({
     "bl quota request --model qwen3.6-plus --tpm 8000000 --yes",
     "bl quota request --model qwen-turbo --tpm 100000 --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelName = flags.model as string;
+  async run(config, flags) {
+    const modelName = flags.model;
     if (!modelName) {
       process.stderr.write("Error: --model is required.\n");
       process.exit(1);

--- a/packages/cli/src/commands/search/web.ts
+++ b/packages/cli/src/commands/search/web.ts
@@ -2,8 +2,6 @@ import {
   defineCommand,
   detectOutputFormat,
   mcpWebSearchEndpoint,
-  type Config,
-  type GlobalFlags,
   isInteractive,
   McpClient,
 } from "bailian-cli-core";
@@ -26,7 +24,7 @@ export default defineCommand({
     'bl search web --query "今日新闻"',
     "bl search web --list-tools",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const mcpUrl = mcpWebSearchEndpoint(config.baseUrl);
     const format = detectOutputFormat(config.output);
 
@@ -46,7 +44,7 @@ export default defineCommand({
     }
 
     // --- Search mode ---
-    let query = flags.query as string | undefined;
+    let query = flags.query;
     if (!query) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({ message: "Enter your search query:" });
@@ -68,7 +66,7 @@ export default defineCommand({
           tool: "bailian_web_search",
           arguments: {
             query: query!,
-            count: (flags.count as number) || undefined,
+            count: flags.count || undefined,
           },
         },
         format,
@@ -89,7 +87,7 @@ export default defineCommand({
 
       // Build tool arguments
       const toolArgs: Record<string, unknown> = { query: query! };
-      if (flags.count) toolArgs.count = flags.count as number;
+      if (flags.count) toolArgs.count = flags.count;
 
       // Call the search tool
       const result = await client.callTool("bailian_web_search", toolArgs);

--- a/packages/cli/src/commands/speech/recognize.ts
+++ b/packages/cli/src/commands/speech/recognize.ts
@@ -60,11 +60,11 @@ export default defineCommand({
     "bl speech recognize --url https://example.com/audio.mp3 --out result.json",
     "bl speech recognize --url https://example.com/audio.mp3 --no-wait --quiet",
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     // Normalize --url to string[] (supports both single and repeated flags)
     let rawUrls: string[] = [];
     if (Array.isArray(flags.url)) {
-      rawUrls = flags.url as string[];
+      rawUrls = flags.url;
     } else if (typeof flags.url === "string") {
       rawUrls = [flags.url];
     }
@@ -73,7 +73,7 @@ export default defineCommand({
     }
 
     // Strict validation: --speaker-count requires --diarization
-    const speakerCount = flags.speakerCount as number | undefined;
+    const speakerCount = flags.speakerCount;
     const diarization = flags.diarization === true;
     if (speakerCount !== undefined && !diarization) {
       throw new BailianError(
@@ -82,7 +82,7 @@ export default defineCommand({
       );
     }
 
-    const model = (flags.model as string) || "fun-asr";
+    const model = flags.model || "fun-asr";
     const format = detectOutputFormat(config.output);
 
     // Auto-upload local files in parallel
@@ -90,9 +90,9 @@ export default defineCommand({
     const resolvedUrls = await Promise.all(
       rawUrls.map((u) => resolveFileUrl(u, credential.token, model)),
     );
-    const channelId = flags.channelId as number | undefined;
-    const language = flags.language as string | undefined;
-    const vocabularyId = flags.vocabularyId as string | undefined;
+    const channelId = flags.channelId;
+    const language = flags.language;
+    const vocabularyId = flags.vocabularyId;
 
     const body: DashScopeASRRequest = {
       model,

--- a/packages/cli/src/commands/speech/synthesize.ts
+++ b/packages/cli/src/commands/speech/synthesize.ts
@@ -192,8 +192,8 @@ export default defineCommand({
     "# Pipe to ffplay",
     'bl speech synthesize --text "Hello" --voice <voice_id> --stream | ffplay -nodisp -autoexit -f s16le -ar 24000 -ac 1 -',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const model = (flags.model as string) || config.defaultSpeechModel || "cosyvoice-v3-flash";
+  async run(config, flags) {
+    const model = flags.model || config.defaultSpeechModel || "cosyvoice-v3-flash";
 
     // --list-voices: print voice list for the model and exit
     if (flags.listVoices) {
@@ -201,11 +201,11 @@ export default defineCommand({
       return;
     }
 
-    let text = flags.text as string | undefined;
+    let text = flags.text;
 
     // --text-file takes precedence if provided and --text is empty
     if (!text && flags.textFile) {
-      const filePath = flags.textFile as string;
+      const filePath = flags.textFile;
       try {
         text = readFileSync(filePath, "utf-8").trim();
       } catch {
@@ -226,7 +226,7 @@ export default defineCommand({
       }
     }
 
-    let voice = (flags.voice as string) || undefined;
+    let voice = flags.voice || undefined;
 
     // In interactive mode, prompt the user to select / enter a voice
     if (!voice) {
@@ -275,8 +275,8 @@ export default defineCommand({
       }
     }
 
-    const language = (flags.language as string) || undefined;
-    const instruction = (flags.instruction as string) || undefined;
+    const language = flags.language || undefined;
+    const instruction = flags.instruction || undefined;
     const audioFormat = (flags.format as "mp3" | "pcm" | "wav" | "opus") || undefined;
     const sampleRate = flags.sampleRate !== undefined ? Number(flags.sampleRate) : undefined;
     const volume = flags.volume !== undefined ? Number(flags.volume) : undefined;

--- a/packages/cli/src/commands/text/chat.ts
+++ b/packages/cli/src/commands/text/chat.ts
@@ -5,7 +5,6 @@ import {
   chatEndpoint,
   parseSSE,
   detectOutputFormat,
-  type Config,
   type GlobalFlags,
   type ChatMessage,
   type ChatRequest,
@@ -115,7 +114,7 @@ export default defineCommand({
     'bl text chat --message "Hello" --output json',
     'bl text chat --model qwq-plus --message "Solve 1+1" --enable-thinking',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const { system, messages: parsedMessages } = parseMessages(flags);
     let messages = parsedMessages;
 
@@ -134,7 +133,7 @@ export default defineCommand({
       }
     }
 
-    const model = (flags.model as string) || config.defaultTextModel || "qwen3.7-max";
+    const model = flags.model || config.defaultTextModel || "qwen3.7-max";
     const shouldStream =
       flags.stream === true || (flags.stream === undefined && process.stdout.isTTY);
     const format = detectOutputFormat(config.output);
@@ -149,22 +148,22 @@ export default defineCommand({
     const body: ChatRequest = {
       model,
       messages: allMessages,
-      max_tokens: (flags.maxTokens as number) ?? 4096,
+      max_tokens: flags.maxTokens ?? 4096,
       stream: shouldStream,
     };
 
-    if (flags.temperature !== undefined) body.temperature = flags.temperature as number;
-    if (flags.topP !== undefined) body.top_p = flags.topP as number;
+    if (flags.temperature !== undefined) body.temperature = flags.temperature;
+    if (flags.topP !== undefined) body.top_p = flags.topP;
 
     if (flags.enableThinking) {
       body.enable_thinking = true;
       if (flags.thinkingBudget !== undefined) {
-        body.thinking_budget = flags.thinkingBudget as number;
+        body.thinking_budget = flags.thinkingBudget;
       }
     }
 
     if (flags.tool) {
-      const tools = (flags.tool as string[]).map((t) => {
+      const tools = flags.tool.map((t) => {
         try {
           return JSON.parse(t);
         } catch {

--- a/packages/cli/src/commands/usage/free.ts
+++ b/packages/cli/src/commands/usage/free.ts
@@ -5,7 +5,6 @@ import {
   fetchModelList,
   detectOutputFormat,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -227,11 +226,11 @@ export default defineCommand({
     "bl usage free --model qwen-turbo --output json",
     "bl usage free --model qwen3-max --console-region cn-beijing",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelFlag = (flags.model as string) || undefined;
+  async run(config, flags) {
+    const modelFlag = flags.model || undefined;
     const expiringDays = Number(flags.expiring) || 0;
     const VALID_SORT_FIELDS = ["remaining", "expires"] as const;
-    const sortField = (flags.sort as string) || undefined;
+    const sortField = flags.sort || undefined;
     if (sortField && !VALID_SORT_FIELDS.includes(sortField as (typeof VALID_SORT_FIELDS)[number])) {
       process.stderr.write(
         `Error: invalid --sort value "${sortField}". Must be one of: ${VALID_SORT_FIELDS.join(", ")}\n`,

--- a/packages/cli/src/commands/usage/freetier.ts
+++ b/packages/cli/src/commands/usage/freetier.ts
@@ -5,7 +5,6 @@ import {
   fetchModelList,
   detectOutputFormat,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 
@@ -140,8 +139,8 @@ export default defineCommand({
     "bl usage freetier --off --model qwen3-max",
     "bl usage freetier --off --all",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelFlag = (flags.model as string) || undefined;
+  async run(config, flags) {
+    const modelFlag = flags.model || undefined;
     const all = Boolean(flags.all);
     const off = Boolean(flags.off);
     const format = detectOutputFormat(config.output);

--- a/packages/cli/src/commands/usage/stats.ts
+++ b/packages/cli/src/commands/usage/stats.ts
@@ -4,7 +4,6 @@ import {
   resolveConsoleGatewayCredential,
   detectOutputFormat,
   type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -343,13 +342,13 @@ export default defineCommand({
     "bl usage stats --type Text --days 14",
     "bl usage stats --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const modelFlag = (flags.model as string) || undefined;
+  async run(config, flags) {
+    const modelFlag = flags.model || undefined;
     const daysFlag = Number(flags.days) || 7;
-    const typeFlag = (flags.type as string) || undefined;
+    const typeFlag = flags.type || undefined;
     const format = detectOutputFormat(config.output);
 
-    const flagWorkspaceId = (flags.workspaceId as string) || undefined;
+    const flagWorkspaceId = flags.workspaceId || undefined;
     const workspaceId = resolveWorkspaceId(config, flagWorkspaceId);
 
     const credential = await resolveConsoleGatewayCredential(config);

--- a/packages/cli/src/commands/video/download.ts
+++ b/packages/cli/src/commands/video/download.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   taskEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type DashScopeTaskResponse,
   BailianError,
   ExitCode,
@@ -25,11 +23,11 @@ export default defineCommand({
     "bl video download --task-id 3b256896-xxxx --out video.mp4",
     "bl video download --task-id 3b256896-xxxx --out video.mp4 --quiet",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const taskId = flags.taskId as string | undefined;
+  async run(config, flags) {
+    const taskId = flags.taskId;
     if (!taskId) failIfMissing("task-id", "bl video download --task-id <id> --out <path>");
 
-    const outPath = flags.out as string | undefined;
+    const outPath = flags.out;
     if (!outPath) failIfMissing("out", "bl video download --task-id <id> --out video.mp4");
 
     const format = detectOutputFormat(config.output);

--- a/packages/cli/src/commands/video/edit.ts
+++ b/packages/cli/src/commands/video/edit.ts
@@ -4,8 +4,6 @@ import {
   videoGenerateEndpoint,
   taskEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type DashScopeVideoEditRequest,
   type DashScopeAsyncResponse,
   type DashScopeTaskResponse,
@@ -83,9 +81,9 @@ export default defineCommand({
     'bl video edit --video https://example.com/input.mp4 --prompt "Convert to anime style" --resolution 720P --download output.mp4',
     'bl video edit --video https://example.com/input.mp4 --prompt "给视频里的小猫穿上衣服" --watermark false',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     // --- Validate video URL ---
-    let videoUrl = flags.video as string | undefined;
+    let videoUrl = flags.video;
     if (!videoUrl) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({ message: "Enter the video URL to edit:" });
@@ -100,7 +98,7 @@ export default defineCommand({
     }
 
     // --- Prompt ---
-    let prompt = flags.prompt as string | undefined;
+    let prompt = flags.prompt;
     if (!prompt) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({ message: "Enter your edit instruction:" });
@@ -113,7 +111,7 @@ export default defineCommand({
       // prompt is optional for video edit per API spec
     }
 
-    const model = (flags.model as string) || "happyhorse-1.0-video-edit";
+    const model = flags.model || "happyhorse-1.0-video-edit";
     const format = detectOutputFormat(config.output);
 
     // Auto-upload local files
@@ -125,7 +123,7 @@ export default defineCommand({
     ];
 
     // Support comma-separated reference images
-    const refImageArg = flags.refImage as string | undefined;
+    const refImageArg = flags.refImage;
     if (refImageArg) {
       const images = refImageArg
         .split(",")
@@ -145,17 +143,17 @@ export default defineCommand({
       model,
       input: {
         prompt: prompt || undefined,
-        negative_prompt: (flags.negativePrompt as string) || undefined,
+        negative_prompt: flags.negativePrompt || undefined,
         media,
       },
       parameters: {
-        resolution: (flags.resolution as string) || undefined,
-        ratio: (flags.ratio as string) || undefined,
-        duration: (flags.duration as number) || undefined,
+        resolution: flags.resolution || undefined,
+        ratio: flags.ratio || undefined,
+        duration: flags.duration || undefined,
         audio_setting: (flags.audioSetting as "auto" | "origin") || undefined,
         prompt_extend: promptExtend,
         watermark,
-        seed: flags.seed as number | undefined,
+        seed: flags.seed,
       },
     };
 
@@ -188,7 +186,7 @@ export default defineCommand({
 
     // --- Poll until completion ---
     // Video editing is compute-intensive; default timeout = 600s (10 min)
-    const pollInterval = (flags.pollInterval as number) ?? 15;
+    const pollInterval = flags.pollInterval ?? 15;
     const pollUrl = taskEndpoint(config.baseUrl, taskId);
     const editTimeout = Math.max(config.timeout, 600);
 
@@ -214,7 +212,7 @@ export default defineCommand({
 
     // --download: save to file
     if (flags.download) {
-      const destPath = flags.download as string;
+      const destPath = flags.download;
       const { size } = await downloadFile(resultVideoUrl, destPath, { quiet: config.quiet });
 
       if (config.quiet) {

--- a/packages/cli/src/commands/video/generate.ts
+++ b/packages/cli/src/commands/video/generate.ts
@@ -4,8 +4,6 @@ import {
   videoGenerateEndpoint,
   taskEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type DashScopeVideoRequest,
   type DashScopeAsyncResponse,
   type DashScopeTaskResponse,
@@ -91,8 +89,8 @@ export default defineCommand({
     'bl video generate --prompt "Mountain landscape" --resolution 1280*720 --duration 5',
     'bl video generate --prompt "A cat playing with a ball" --watermark false',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    let prompt = flags.prompt as string | undefined;
+  async run(config, flags) {
+    let prompt = flags.prompt;
 
     if (!prompt) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
@@ -108,12 +106,12 @@ export default defineCommand({
     }
 
     const model =
-      (flags.model as string) ||
+      flags.model ||
       config.defaultVideoModel ||
-      ((flags.image as string) ? "happyhorse-1.0-i2v" : "happyhorse-1.0-t2v");
+      (flags.image ? "happyhorse-1.0-i2v" : "happyhorse-1.0-t2v");
     const format = detectOutputFormat(config.output);
 
-    const imageUrl = flags.image as string | undefined;
+    const imageUrl = flags.image;
 
     // Auto-upload local image file for i2v
     let resolvedImageUrl: string | undefined;
@@ -129,19 +127,19 @@ export default defineCommand({
       model,
       input: {
         prompt: prompt!,
-        negative_prompt: (flags.negativePrompt as string) || undefined,
+        negative_prompt: flags.negativePrompt || undefined,
         // i2v models (happyhorse-1.0-i2v) require input.media with type 'first_frame'
         ...(resolvedImageUrl
           ? { media: [{ type: "first_frame" as const, url: resolvedImageUrl }] }
           : {}),
       },
       parameters: {
-        resolution: normalizeResolution(flags.resolution as string) || undefined,
-        ratio: (flags.ratio as string) || undefined,
-        duration: (flags.duration as number) || undefined,
+        resolution: normalizeResolution(flags.resolution) || undefined,
+        ratio: flags.ratio || undefined,
+        duration: flags.duration || undefined,
         prompt_extend: promptExtend,
         watermark,
-        seed: flags.seed as number | undefined,
+        seed: flags.seed,
       },
     };
 
@@ -180,7 +178,7 @@ export default defineCommand({
     }
 
     // Poll all tasks concurrently
-    const pollInterval = (flags.pollInterval as number) ?? 5;
+    const pollInterval = flags.pollInterval ?? 5;
 
     const pollPromises = taskIds.map((taskId) => {
       const pollUrl = taskEndpoint(config.baseUrl, taskId);
@@ -217,7 +215,7 @@ export default defineCommand({
 
     // --download: save to file (first video only for explicit path)
     if (flags.download) {
-      const destPath = flags.download as string;
+      const destPath = flags.download;
       const { size } = await downloadFile(videos[0]!.videoUrl, destPath, { quiet: config.quiet });
 
       if (config.quiet) {

--- a/packages/cli/src/commands/video/ref.ts
+++ b/packages/cli/src/commands/video/ref.ts
@@ -4,8 +4,6 @@ import {
   videoGenerateEndpoint,
   taskEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type DashScopeVideoRefRequest,
   type DashScopeAsyncResponse,
   type DashScopeTaskResponse,
@@ -94,9 +92,9 @@ export default defineCommand({
     'bl video ref --prompt "图1和图2在对话" --image a.jpg --image b.jpg --image-voice va.mp3 --image-voice vb.mp3',
     'bl video ref --prompt "图1在喝水" --image person.jpg --watermark false',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     // --- Validate prompt ---
-    let prompt = flags.prompt as string | undefined;
+    let prompt = flags.prompt;
     if (!prompt) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({
@@ -112,8 +110,8 @@ export default defineCommand({
       }
     }
 
-    const images = (flags.image as string[] | undefined) || [];
-    const refVideos = (flags.refVideo as string[] | undefined) || [];
+    const images = flags.image || [];
+    const refVideos = flags.refVideo || [];
 
     if (images.length === 0 && refVideos.length === 0) {
       throw new BailianError(
@@ -123,10 +121,10 @@ export default defineCommand({
       );
     }
 
-    const imageVoices = (flags.imageVoice as string[] | undefined) || [];
-    const videoVoices = (flags.videoVoice as string[] | undefined) || [];
+    const imageVoices = flags.imageVoice || [];
+    const videoVoices = flags.videoVoice || [];
 
-    const model = (flags.model as string) || "happyhorse-1.0-r2v";
+    const model = flags.model || "happyhorse-1.0-r2v";
     const format = detectOutputFormat(config.output);
 
     // --- Resolve file URLs (auto-upload local files) ---
@@ -178,12 +176,12 @@ export default defineCommand({
         media,
       },
       parameters: {
-        resolution: (flags.resolution as string) || undefined,
-        ratio: (flags.ratio as string) || undefined,
-        duration: (flags.duration as number) || undefined,
+        resolution: flags.resolution || undefined,
+        ratio: flags.ratio || undefined,
+        duration: flags.duration || undefined,
         prompt_extend: promptExtend,
         watermark,
-        seed: flags.seed as number | undefined,
+        seed: flags.seed,
       },
     };
 
@@ -217,7 +215,7 @@ export default defineCommand({
     }
 
     // --- Poll until completion ---
-    const pollInterval = (flags.pollInterval as number) ?? 15;
+    const pollInterval = flags.pollInterval ?? 15;
     const pollUrl = taskEndpoint(config.baseUrl, taskId);
     const refTimeout = Math.max(config.timeout, 600);
 
@@ -243,7 +241,7 @@ export default defineCommand({
 
     // --download: save to file
     if (flags.download) {
-      const destPath = flags.download as string;
+      const destPath = flags.download;
       const { size } = await downloadFile(resultVideoUrl, destPath, { quiet: config.quiet });
 
       if (config.quiet) {

--- a/packages/cli/src/commands/video/task-get.ts
+++ b/packages/cli/src/commands/video/task-get.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   taskEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type DashScopeTaskResponse,
 } from "bailian-cli-core";
 import { failIfMissing } from "../../output/prompt.ts";
@@ -19,8 +17,8 @@ export default defineCommand({
     "bl video task get --task-id 3b256896-3e70-xxxx-xxxx-xxxxxxxxxxxx",
     "bl video task get --task-id 3b256896-3e70-xxxx --output json",
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    const taskId = flags.taskId as string | undefined;
+  async run(config, flags) {
+    const taskId = flags.taskId;
     if (!taskId) failIfMissing("task-id", "bl video task get --task-id <id>");
 
     const format = detectOutputFormat(config.output);

--- a/packages/cli/src/commands/vision/describe.ts
+++ b/packages/cli/src/commands/vision/describe.ts
@@ -3,8 +3,6 @@ import {
   requestJson,
   chatEndpoint,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
   type ChatRequest,
   type ChatResponse,
   type ChatMessageContent,
@@ -77,12 +75,10 @@ export default defineCommand({
     "bl vision describe --video ./local-video.mp4",
     'bl vision describe --image photo.png --prompt "Extract the text" --model qwen-vl-plus',
   ],
-  async run(config: Config, flags: GlobalFlags) {
-    let image = (flags.image ?? (flags._positional as string[] | undefined)?.[0]) as
-      | string
-      | undefined;
-    const videoInputs = (flags.video as string[] | undefined) ?? [];
-    const model = (flags.model as string) || "qwen3-vl-plus";
+  async run(config, flags) {
+    let image = flags.image ?? (flags._positional as string[] | undefined)?.[0];
+    const videoInputs = flags.video ?? [];
+    const model = flags.model || "qwen3-vl-plus";
 
     // Auto-detect: if --image was given a video file, treat it as --video
     if (image && isVideoInput(image)) {
@@ -92,7 +88,7 @@ export default defineCommand({
 
     const hasVideo = videoInputs.length > 0;
     const defaultPrompt = hasVideo ? "Describe the video." : "Describe the image.";
-    const prompt = (flags.prompt as string) || defaultPrompt;
+    const prompt = flags.prompt || defaultPrompt;
 
     if (!image && !hasVideo) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {

--- a/packages/cli/src/commands/workspace/list.ts
+++ b/packages/cli/src/commands/workspace/list.ts
@@ -3,8 +3,6 @@ import {
   callConsoleGateway,
   resolveConsoleGatewayCredential,
   detectOutputFormat,
-  type Config,
-  type GlobalFlags,
 } from "bailian-cli-core";
 import { emitResult } from "../../output/output.ts";
 import { displayWidth, padEnd } from "../../output/cjk-width.ts";
@@ -105,7 +103,7 @@ export default defineCommand({
     },
   ],
   examples: ["bl workspace list", "bl workspace list --list 5", "bl workspace list --output json"],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config, flags) {
     const limit = Number(flags.list) || 0;
     const format = detectOutputFormat(config.output);
 

--- a/packages/core/src/types/command.ts
+++ b/packages/core/src/types/command.ts
@@ -8,6 +8,36 @@ export interface OptionDef {
   required?: boolean;
 }
 
+type KebabToCamel<S extends string> = S extends `${infer A}-${infer B}`
+  ? `${A}${Capitalize<KebabToCamel<B>>}`
+  : S;
+
+type ExtractFlagName<S extends string> = S extends `--${infer Name} <${string}>`
+  ? KebabToCamel<Name>
+  : S extends `--${infer Name} [${string}]`
+    ? KebabToCamel<Name>
+    : S extends `--no-${infer Name}`
+      ? KebabToCamel<Name>
+      : S extends `--${infer Name}`
+        ? KebabToCamel<Name>
+        : never;
+
+type FlagValueType<T extends OptionDef> = T["type"] extends "number"
+  ? number
+  : T["type"] extends "boolean"
+    ? true
+    : T["type"] extends "array"
+      ? string[]
+      : T["flag"] extends `--${string} <${string}>`
+        ? string
+        : T["flag"] extends `--${string} [${string}]`
+          ? string
+          : true;
+
+type InferFlags<T extends readonly OptionDef[]> = {
+  [K in T[number] as ExtractFlagName<K["flag"]>]?: FlagValueType<K>;
+};
+
 export interface Command {
   name: string;
   description: string;
@@ -17,23 +47,25 @@ export interface Command {
   execute: (config: Config, flags: GlobalFlags) => Promise<void>;
 }
 
-export interface CommandSpec {
+export interface CommandSpec<Options extends readonly OptionDef[] = OptionDef[]> {
   name: string;
   description: string;
   usage?: string;
-  options?: OptionDef[];
+  options?: Options;
   examples?: string[];
-  run: (config: Config, flags: GlobalFlags) => Promise<void>;
+  run: (config: Config, flags: GlobalFlags & InferFlags<Options>) => Promise<void>;
 }
 
-export function defineCommand(spec: CommandSpec): Command {
+export function defineCommand<const Options extends readonly OptionDef[]>(
+  spec: CommandSpec<Options>,
+): Command {
   return {
     name: spec.name,
     description: spec.description,
     usage: spec.usage,
-    options: spec.options,
+    options: spec.options as OptionDef[] | undefined,
     examples: spec.examples,
-    execute: (config, flags) => spec.run(config, flags),
+    execute: (config, flags) => spec.run(config, flags as GlobalFlags & InferFlags<Options>),
   };
 }
 


### PR DESCRIPTION
Generify CommandSpec and defineCommand so the `run` callback's `flags` parameter is typed as `GlobalFlags & InferFlags<Options>`, where InferFlags derives typed properties from the command's `options` array.

This removes ~150 manual `as string` / `as number` / `as string[]` type assertions across 46 command files.