### PR TITLE
chore(release): align knowledge-studio-cli to 1.5.0

### DIFF
--- a/packages/kscli/package.json
+++ b/packages/kscli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-studio-cli",
-  "version": "0.0.1",
+  "version": "1.5.0",
   "description": "Lightweight RAG CLI for Aliyun Model Studio — focused on knowledge-base retrieval.",
   "keywords": [
     "alibaba-cloud",


### PR DESCRIPTION
kscli joins the family lockstep version so the --knowledge stable publish passes (validate.mjs asserts every package in ALL_PACKAGES matches bailian-cli-core). Was 0.0.1, which blocked publish-stable --knowledge.