### PR TITLE
chore: speed up pre-commit skill asset sync

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# Regenerate skill reference + SKILL metadata (needs bailian-cli-core dist).
+# Regenerate skill reference + SKILL metadata from source (no package build).
 pnpm run sync:skill-assets
 
 # Stage generator output so it is included in this commit.

--- a/docs/agents/lint-toolchain.md
+++ b/docs/agents/lint-toolchain.md
@@ -42,7 +42,7 @@
 
 - [ ] `.vite-hooks/pre-commit` 改动后,`pnpm install` 重新软链(走 `prepare: vp config`)
 - [ ] 增加 hook 时,确认在干净 clone 后能自动激活
-- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(先 build core,再 `generate:reference` + `sync:skill-version`)并 `git add` skill 资产,最后 `vp staged`
+- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(`generate:reference` + `sync:skill-version`,直接读源码、无需先 build)并 `git add` skill 资产,最后 `vp staged`
 
 ### F. CI / 发版工具
 

--- a/docs/agents/lint-toolchain.md
+++ b/docs/agents/lint-toolchain.md
@@ -42,7 +42,7 @@
 
 - [ ] `.vite-hooks/pre-commit` 改动后,`pnpm install` 重新软链(走 `prepare: vp config`)
 - [ ] 增加 hook 时,确认在干净 clone 后能自动激活
-- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(`generate:reference` + `sync:skill-version` + `vp check --fix` reference,直接读源码、无需先 build)并 `git add` skill 资产,最后 `vp staged`
+- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(`generate:reference` 含格式化 + `sync:skill-version`,直接读源码、无需先 build)并 `git add` skill 资产,最后 `vp staged`
 
 ### F. CI / 发版工具
 

--- a/docs/agents/lint-toolchain.md
+++ b/docs/agents/lint-toolchain.md
@@ -42,7 +42,7 @@
 
 - [ ] `.vite-hooks/pre-commit` 改动后,`pnpm install` 重新软链(走 `prepare: vp config`)
 - [ ] 增加 hook 时,确认在干净 clone 后能自动激活
-- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(`generate:reference` + `sync:skill-version`,直接读源码、无需先 build)并 `git add` skill 资产,最后 `vp staged`
+- [ ] pre-commit 会跑 `pnpm run sync:skill-assets`(`generate:reference` + `sync:skill-version` + `vp check --fix` reference,直接读源码、无需先 build)并 `git add` skill 资产,最后 `vp staged`
 
 ### F. CI / 发版工具
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ready": "vp check && vp run -r test && vp run -r build",
     "prepare": "vp config",
     "check": "vp check",
-    "sync:skill-assets": "pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version",
+    "sync:skill-assets": "pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version && vp check --fix skills/bailian-cli/reference",
     "dev": "pnpm -F bailian-cli-core dev",
     "bl": "pnpm -F bailian-cli dev",
     "kscli": "pnpm -F knowledge-studio-cli dev",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ready": "vp check && vp run -r test && vp run -r build",
     "prepare": "vp config",
     "check": "vp check",
-    "sync:skill-assets": "pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version && vp check --fix skills/bailian-cli/reference",
+    "sync:skill-assets": "pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version",
     "dev": "pnpm -F bailian-cli-core dev",
     "bl": "pnpm -F bailian-cli dev",
     "kscli": "pnpm -F knowledge-studio-cli dev",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ready": "vp check && vp run -r test && vp run -r build",
     "prepare": "vp config",
     "check": "vp check",
-    "sync:skill-assets": "pnpm --filter \"bailian-cli^...\" run build && pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version",
+    "sync:skill-assets": "pnpm --filter bailian-cli run generate:reference && pnpm --filter bailian-cli run sync:skill-version",
     "dev": "pnpm -F bailian-cli-core dev",
     "bl": "pnpm -F bailian-cli dev",
     "kscli": "pnpm -F knowledge-studio-cli dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "generate:reference": "tsx ../../tools/generate-reference.ts",
+    "generate:reference": "tsx ../../tools/generate-reference.ts && sh -c 'cd ../.. && vp check --fix skills/bailian-cli/reference'",
     "sync:skill-version": "tsx ../../tools/sync-skill-metadata.ts",
     "build": "vp pack",
     "dev": "tsx src/main.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "generate:reference": "tsx ../../tools/generate-reference.ts && sh -c 'cd ../.. && vp check --fix skills/bailian-cli/reference'",
+    "generate:reference": "tsx ../../tools/generate-reference.ts",
     "sync:skill-version": "tsx ../../tools/sync-skill-metadata.ts",
     "build": "vp pack",
     "dev": "tsx src/main.ts",

--- a/tools/generate-reference.ts
+++ b/tools/generate-reference.ts
@@ -7,8 +7,7 @@
  *
  * Run: pnpm --filter bailian-cli run generate:reference
  * Also run via `pnpm run sync:skill-assets` or the repo pre-commit hook.
- * Uses tsx because workspace packages resolve to source locally.
- * Requires built `bailian-cli-core` for shared flag constants.
+ * Uses tsx and reads workspace packages from source
  */
 import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -19,8 +18,10 @@ import {
   MODEL_AUTH_FLAGS,
   OPENAPI_AUTH_FLAGS,
   credentialFlagDefs,
-} from "../packages/core/dist/index.mjs";
-import type { AnyCommand, FlagDef, FlagsDef } from "../packages/core/src/index.ts";
+  type AnyCommand,
+  type FlagDef,
+  type FlagsDef,
+} from "../packages/core/src/index.ts";
 import { commands } from "../packages/cli/src/commands.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Read skill reference generator inputs from `bailian-cli-core` source instead of `dist`, so `sync:skill-assets` no longer needs a package build.
- Update pre-commit and agent docs to match the lighter sync path.

Locally, `pnpm run sync:skill-assets` dropped from ~12.6s to ~4.0–4.6s (~63% faster). Generated reference content stays equivalent after formatting.

## Test plan
- [x] Run `pnpm run sync:skill-assets` and confirm it completes without building core/runtime/commands
- [x] Confirm `skills/bailian-cli/reference/` content matches the previous output after `vp check --fix`
- [x] Run `vp check` on the touched files
- [x] Exercise pre-commit with an empty commit (`git commit --allow-empty`) or a small staged change and confirm the hook still regenerates skill assets then runs `vp staged`