### PR TITLE
feat(cli): 添加 @ali/bailian-plugin-inner-console-call 插件的命令前缀配置

### DIFF
--- a/packages/cli/src/command-pack-policy.ts
+++ b/packages/cli/src/command-pack-policy.ts
@@ -7,5 +7,8 @@ export const commandPackPolicy = {
       commandPrefixes: ["agent"],
       credentialAccess: ["apiKey"],
     },
+    "@ali/bailian-plugin-inner-console-call": {
+      commandPrefixes: ["inner-console"],
+    },
   },
 } as const satisfies CommandPackPolicy;


### PR DESCRIPTION
- 为插件 @ali/bailian-plugin-inner-console-call 添加命令前缀 inner-console
- 扩展了命令包策略以支持新的插件命令调用
- 确保命令前缀统一管理，提高插件识别准确性