### PR TITLE
docs(readme): add `bl config agent` example to Configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ bl config set --key base_url --value https://dashscope-us.aliyuncs.com
 bl config set --key default_text_model --value qwen-turbo
 bl config set --key timeout --value 600
 
+# Configure a coding agent (Claude Code, Qwen Code, OpenCode, OpenClaw, Hermes, Codex)
+# to use DashScope with one command
+bl config agent --agent claude-code \
+  --base-url https://dashscope.aliyuncs.com/apps/anthropic \
+  --api-key sk-xxxxx --model qwen3-max
+
 # Self-update to latest version
 bl update
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -208,6 +208,11 @@ bl config set --key base_url --value https://dashscope-us.aliyuncs.com
 bl config set --key default_text_model --value qwen-turbo
 bl config set --key timeout --value 600
 
+# 一键配置编程 Agent（Claude Code、Qwen Code、OpenCode、OpenClaw、Hermes、Codex）接入百炼
+bl config agent --agent claude-code \
+  --base-url https://dashscope.aliyuncs.com/apps/anthropic \
+  --api-key sk-xxxxx --model qwen3-max
+
 # 自更新到最新版本
 bl update
 ```


### PR DESCRIPTION
## Summary

Document the one-command coding-agent setup (`bl config agent`) in the Configuration section of both `README.md` and `README.zh.md`. Shows how to point Claude Code / Qwen Code / OpenCode / OpenClaw / Hermes / Codex at DashScope in a single command.

Docs-only change (11 lines, no code). Branched off latest `main`.

## Test plan

- N/A (documentation only). Rendered Markdown reviewed.
