### PR TITLE
feat(cli): show command authentication requirements in help

### DIFF
--- a/packages/cli/tests/e2e/registry.smoke.e2e.test.ts
+++ b/packages/cli/tests/e2e/registry.smoke.e2e.test.ts
@@ -7,15 +7,38 @@ const commandPaths = Object.keys(commands).sort();
 const groupPaths = deriveGroupPaths(commandPaths);
 
 describe("e2e: bl registry smoke", () => {
-  test("根帮助展示 bl 与全局 flag", async () => {
+  test("根帮助展示 bl、逐命令鉴权域与全局 flag", async () => {
     const { stderr, exitCode } = await runCli(["--help"]);
     expect(exitCode, stderr).toBe(0);
     expect(stderr).toMatch(/\bbl\b/i);
+    expect(stderr).not.toMatch(/COMMAND\s+AUTH\s+DESCRIPTION/);
+    expect(stderr).toMatch(/app call\s+\[API Key\]\s+Call a Bailian application/);
+    expect(stderr).toMatch(/app list\s+\[Console\]\s+List Bailian applications/);
+    expect(stderr).toMatch(/token-plan create-key\s+\[AK\/SK\]\s+Create a Token Plan API key/);
+    expect(stderr).toMatch(/config show\s+\[No Auth\]\s+Display current configuration/);
     expect(stderr).toMatch(/--base-url/);
     expect(stderr).toMatch(/--console-region/);
     expect(stderr).toMatch(/--console-site/);
     expect(stderr).toMatch(/--console-switch-agent/);
     expect(stderr).not.toMatch(/^\s*--region\s/m);
+  });
+
+  test("分组帮助按叶子命令展示不同鉴权域", async () => {
+    const { stderr, exitCode } = await runCli(["app", "--help"]);
+    expect(exitCode, stderr).toBe(0);
+    expect(stderr).toMatch(/app call\s+\[API Key\]\s+Call a Bailian application/);
+    expect(stderr).toMatch(/app list\s+\[Console\]\s+List Bailian applications/);
+  });
+
+  test.each([
+    [["text", "chat"], "API Key"],
+    [["app", "list"], "Console"],
+    [["token-plan", "list-seats"], "AK/SK"],
+    [["config", "show"], "No Auth"],
+  ] as const)("%s --help 明确展示鉴权域 %s", async (commandPath, authLabel) => {
+    const { stderr, exitCode } = await runCli([...commandPath, "--help"]);
+    expect(exitCode, stderr).toBe(0);
+    expect(stderr).toContain(`Authentication: ${authLabel}`);
   });
 
   test("quota check --help:Flags 含 console 域鉴权 flag,Global Flags 全量列出", async () => {

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -25,6 +25,13 @@ interface CommandNode {
   children: Map<string, CommandNode>;
 }
 
+const AUTH_LABELS = {
+  apiKey: "API Key",
+  console: "Console",
+  openapi: "AK/SK",
+  none: "No Auth",
+} satisfies Record<AuthRequirement, string>;
+
 /**
  * What a command path resolves to in the registry. The single judgement that
  * feeds `resolve()` — no scattered `isGroupPath` + throwing `resolve`.
@@ -157,14 +164,37 @@ export class CommandRegistry {
     };
   }
 
-  private buildResourceLines(a: (s: string) => string, d: (s: string) => string): string {
-    const entries: Array<{ path: string; desc: string }> = [];
+  private buildCommandLines(
+    entries: Array<{ path: string; auth: AuthRequirement; desc: string }>,
+    accent: (text: string) => string,
+    dim: (text: string) => string,
+  ): string {
+    const maxPathLength = Math.max(...entries.map((entry) => entry.path.length));
+    const maxAuthLength = Math.max(
+      ...entries.map((entry) => `[${AUTH_LABELS[entry.auth]}]`.length),
+    );
+    const rows = entries.map((entry) => {
+      const authLabel = `[${AUTH_LABELS[entry.auth]}]`;
+      return `  ${accent(entry.path.padEnd(maxPathLength + 2))} ${accent(authLabel.padEnd(maxAuthLength + 2))} ${dim(entry.desc)}`;
+    });
+    return rows.join("\n");
+  }
+
+  private buildResourceLines(
+    accent: (text: string) => string,
+    dim: (text: string) => string,
+  ): string {
+    const entries: Array<{ path: string; auth: AuthRequirement; desc: string }> = [];
 
     const collect = (node: CommandNode, prefix: string) => {
       for (const [name, child] of node.children) {
         const fullPath = prefix ? `${prefix} ${name}` : name;
         if (child.command) {
-          entries.push({ path: fullPath, desc: child.command.description });
+          entries.push({
+            path: fullPath,
+            auth: child.command.auth,
+            desc: child.command.description,
+          });
         }
         if (child.children.size > 0) {
           collect(child, fullPath);
@@ -173,8 +203,7 @@ export class CommandRegistry {
     };
     collect(this.root, "");
 
-    const maxLen = Math.max(...entries.map((e) => e.path.length));
-    return entries.map((e) => `  ${a(e.path.padEnd(maxLen + 2))} ${d(e.desc)}`).join("\n");
+    return this.buildCommandLines(entries, accent, dim);
   }
 
   private buildFlagLines(
@@ -341,6 +370,7 @@ ${authFlagSections ? `${authFlagSections}\n\n` : ""}${b("Getting Help:")}
 
     out.write(`\n${cmd.description}\n`);
     out.write(`${b("Usage:")} ${prefix}${cmd.usageArgs ? ` ${cmd.usageArgs}` : ""}\n`);
+    out.write(`${b("Authentication:")} ${a(AUTH_LABELS[cmd.auth])}\n`);
     const flagEntries = [
       ...Object.entries(cmd.flags ?? {}),
       ...Object.entries(credentialFlagDefs(cmd)),
@@ -373,18 +403,25 @@ ${authFlagSections ? `${authFlagSections}\n\n` : ""}${b("Getting Help:")}
   }
 
   private printChildren(node: CommandNode, prefix: string, out: NodeJS.WriteStream): void {
-    const entries: Array<{ fullName: string; description: string }> = [];
-    const collect = (n: CommandNode, p: string) => {
-      for (const [name, child] of n.children) {
+    const entries: Array<{ path: string; auth: AuthRequirement; desc: string }> = [];
+    const collect = (currentNode: CommandNode, currentPath: string) => {
+      for (const [name, child] of currentNode.children) {
         if (child.command)
-          entries.push({ fullName: `${p} ${name}`, description: child.command.description });
-        if (child.children.size > 0) collect(child, `${p} ${name}`);
+          entries.push({
+            path: `${currentPath} ${name}`,
+            auth: child.command.auth,
+            desc: child.command.description,
+          });
+        if (child.children.size > 0) collect(child, `${currentPath} ${name}`);
       }
     };
     collect(node, prefix);
-    const maxLen = Math.max(...entries.map((e) => e.fullName.length));
-    for (const { fullName, description } of entries) {
-      out.write(`  ${this.accent(fullName.padEnd(maxLen), out)}  ${this.dim(description, out)}\n`);
-    }
+    out.write(
+      this.buildCommandLines(
+        entries,
+        (text) => this.accent(text, out),
+        (text) => this.dim(text, out),
+      ) + "\n",
+    );
   }
 }

--- a/skills/bailian-cli/reference/advisor.md
+++ b/skills/bailian-cli/reference/advisor.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                | Description                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `bl advisor recommend` | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) |
+| Command                | Authentication | Description                                                                                    |
+| ---------------------- | -------------- | ---------------------------------------------------------------------------------------------- |
+| `bl advisor recommend` | API Key        | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) |
 
 ## Command details
 
 ### `bl advisor recommend`
 
-| Field           | Value                                                                                          |
-| --------------- | ---------------------------------------------------------------------------------------------- |
-| **Name**        | `advisor recommend`                                                                            |
-| **Description** | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) |
-| **Usage**       | `bl advisor recommend --message <text> [flags]`                                                |
+| Field              | Value                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| **Name**           | `advisor recommend`                                                                            |
+| **Description**    | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) |
+| **Authentication** | API Key                                                                                        |
+| **Usage**          | `bl advisor recommend --message <text> [flags]`                                                |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/app.md
+++ b/skills/bailian-cli/reference/app.md
@@ -7,20 +7,21 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command       | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `bl app call` | Call a Bailian application (agent or workflow) |
-| `bl app list` | List Bailian applications                      |
+| Command       | Authentication | Description                                    |
+| ------------- | -------------- | ---------------------------------------------- |
+| `bl app call` | API Key        | Call a Bailian application (agent or workflow) |
+| `bl app list` | Console        | List Bailian applications                      |
 
 ## Command details
 
 ### `bl app call`
 
-| Field           | Value                                               |
-| --------------- | --------------------------------------------------- |
-| **Name**        | `app call`                                          |
-| **Description** | Call a Bailian application (agent or workflow)      |
-| **Usage**       | `bl app call --app-id <id> --prompt <text> [flags]` |
+| Field              | Value                                               |
+| ------------------ | --------------------------------------------------- |
+| **Name**           | `app call`                                          |
+| **Description**    | Call a Bailian application (agent or workflow)      |
+| **Authentication** | API Key                                             |
+| **Usage**          | `bl app call --app-id <id> --prompt <text> [flags]` |
 
 #### Flags
 
@@ -67,11 +68,12 @@ bl app call --app-id abc123 --prompt "Start" --biz-params '{"key":"value"}'
 
 ### `bl app list`
 
-| Field           | Value                     |
-| --------------- | ------------------------- |
-| **Name**        | `app list`                |
-| **Description** | List Bailian applications |
-| **Usage**       | `bl app list [flags]`     |
+| Field              | Value                     |
+| ------------------ | ------------------------- |
+| **Name**           | `app list`                |
+| **Description**    | List Bailian applications |
+| **Authentication** | Console                   |
+| **Usage**          | `bl app list [flags]`     |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/auth.md
+++ b/skills/bailian-cli/reference/auth.md
@@ -7,22 +7,23 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                         | Description                                                                                  |
-| ------------------------------- | -------------------------------------------------------------------------------------------- |
-| `bl auth generate-access-token` | Generate a CLI access token using OpenAPI AK/SK                                              |
-| `bl auth login`                 | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist) |
-| `bl auth logout`                | Clear stored credentials; full logout also clears the model Base URL                         |
-| `bl auth status`                | Show current authentication state                                                            |
+| Command                         | Authentication | Description                                                                                  |
+| ------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `bl auth generate-access-token` | No Auth        | Generate a CLI access token using OpenAPI AK/SK                                              |
+| `bl auth login`                 | No Auth        | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist) |
+| `bl auth logout`                | No Auth        | Clear stored credentials; full logout also clears the model Base URL                         |
+| `bl auth status`                | No Auth        | Show current authentication state                                                            |
 
 ## Command details
 
 ### `bl auth generate-access-token`
 
-| Field           | Value                                                                                                      |
-| --------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Name**        | `auth generate-access-token`                                                                               |
-| **Description** | Generate a CLI access token using OpenAPI AK/SK                                                            |
-| **Usage**       | `bl auth generate-access-token --access-key-id <id> --access-key-secret <secret> --security-token <token>` |
+| Field              | Value                                                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Name**           | `auth generate-access-token`                                                                               |
+| **Description**    | Generate a CLI access token using OpenAPI AK/SK                                                            |
+| **Authentication** | No Auth                                                                                                    |
+| **Usage**          | `bl auth generate-access-token --access-key-id <id> --access-key-secret <secret> --security-token <token>` |
 
 #### Flags
 
@@ -40,11 +41,12 @@ bl auth generate-access-token --access-key-id LTAIxxxxx --access-key-secret xxxx
 
 ### `bl auth login`
 
-| Field           | Value                                                                                                        |
-| --------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Name**        | `auth login`                                                                                                 |
-| **Description** | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist)                 |
-| **Usage**       | `bl auth login --api-key <key> \| --console \| --open-api --access-key-id <id> --access-key-secret <secret>` |
+| Field              | Value                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| **Name**           | `auth login`                                                                                                 |
+| **Description**    | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist)                 |
+| **Authentication** | No Auth                                                                                                      |
+| **Usage**          | `bl auth login --api-key <key> \| --console \| --open-api --access-key-id <id> --access-key-secret <secret>` |
 
 #### Flags
 
@@ -78,11 +80,12 @@ bl auth login --open-api --access-key-id LTAIxxxxx --access-key-secret xxxxx
 
 ### `bl auth logout`
 
-| Field           | Value                                                                |
-| --------------- | -------------------------------------------------------------------- |
-| **Name**        | `auth logout`                                                        |
-| **Description** | Clear stored credentials; full logout also clears the model Base URL |
-| **Usage**       | `bl auth logout [--console \| --open-api] [--dry-run]`               |
+| Field              | Value                                                                |
+| ------------------ | -------------------------------------------------------------------- |
+| **Name**           | `auth logout`                                                        |
+| **Description**    | Clear stored credentials; full logout also clears the model Base URL |
+| **Authentication** | No Auth                                                              |
+| **Usage**          | `bl auth logout [--console \| --open-api] [--dry-run]`               |
 
 #### Flags
 
@@ -111,11 +114,12 @@ bl auth logout --dry-run
 
 ### `bl auth status`
 
-| Field           | Value                             |
-| --------------- | --------------------------------- |
-| **Name**        | `auth status`                     |
-| **Description** | Show current authentication state |
-| **Usage**       | `bl auth status`                  |
+| Field              | Value                             |
+| ------------------ | --------------------------------- |
+| **Name**           | `auth status`                     |
+| **Description**    | Show current authentication state |
+| **Authentication** | No Auth                           |
+| **Usage**          | `bl auth status`                  |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/config.md
+++ b/skills/bailian-cli/reference/config.md
@@ -7,24 +7,25 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command           | Description                                      |
-| ----------------- | ------------------------------------------------ |
-| `bl config agent` | Configure a coding agent to use DashScope API    |
-| `bl config list`  | List config profiles and show the active profile |
-| `bl config set`   | Set a config value                               |
-| `bl config show`  | Display current configuration                    |
-| `bl config ui`    | Open a local web UI to manage config profiles    |
-| `bl config use`   | Set the active config profile                    |
+| Command           | Authentication | Description                                      |
+| ----------------- | -------------- | ------------------------------------------------ |
+| `bl config agent` | No Auth        | Configure a coding agent to use DashScope API    |
+| `bl config list`  | No Auth        | List config profiles and show the active profile |
+| `bl config set`   | No Auth        | Set a config value                               |
+| `bl config show`  | No Auth        | Display current configuration                    |
+| `bl config ui`    | No Auth        | Open a local web UI to manage config profiles    |
+| `bl config use`   | No Auth        | Set the active config profile                    |
 
 ## Command details
 
 ### `bl config agent`
 
-| Field           | Value                                                                                                                         |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `config agent`                                                                                                                |
-| **Description** | Configure a coding agent to use DashScope API                                                                                 |
-| **Usage**       | `bl config agent --agent <name> (--base-url <url> \| --region <region>) (--api-key <key> \| --key <encoded>) --model <model>` |
+| Field              | Value                                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `config agent`                                                                                                                |
+| **Description**    | Configure a coding agent to use DashScope API                                                                                 |
+| **Authentication** | No Auth                                                                                                                       |
+| **Usage**          | `bl config agent --agent <name> (--base-url <url> \| --region <region>) (--api-key <key> \| --key <encoded>) --model <model>` |
 
 #### Flags
 
@@ -55,11 +56,12 @@ bl config agent --agent codex --base-url https://dashscope.aliyuncs.com/compatib
 
 ### `bl config list`
 
-| Field           | Value                                            |
-| --------------- | ------------------------------------------------ |
-| **Name**        | `config list`                                    |
-| **Description** | List config profiles and show the active profile |
-| **Usage**       | `bl config list`                                 |
+| Field              | Value                                            |
+| ------------------ | ------------------------------------------------ |
+| **Name**           | `config list`                                    |
+| **Description**    | List config profiles and show the active profile |
+| **Authentication** | No Auth                                          |
+| **Usage**          | `bl config list`                                 |
 
 #### Flags
 
@@ -77,11 +79,12 @@ bl config list --output json
 
 ### `bl config set`
 
-| Field           | Value                                       |
-| --------------- | ------------------------------------------- |
-| **Name**        | `config set`                                |
-| **Description** | Set a config value                          |
-| **Usage**       | `bl config set --key <key> --value <value>` |
+| Field              | Value                                       |
+| ------------------ | ------------------------------------------- |
+| **Name**           | `config set`                                |
+| **Description**    | Set a config value                          |
+| **Authentication** | No Auth                                     |
+| **Usage**          | `bl config set --key <key> --value <value>` |
 
 #### Flags
 
@@ -106,11 +109,12 @@ bl config set --key base_url --value https://dashscope.aliyuncs.com
 
 ### `bl config show`
 
-| Field           | Value                         |
-| --------------- | ----------------------------- |
-| **Name**        | `config show`                 |
-| **Description** | Display current configuration |
-| **Usage**       | `bl config show`              |
+| Field              | Value                         |
+| ------------------ | ----------------------------- |
+| **Name**           | `config show`                 |
+| **Description**    | Display current configuration |
+| **Authentication** | No Auth                       |
+| **Usage**          | `bl config show`              |
 
 #### Flags
 
@@ -128,11 +132,12 @@ bl config show --output json
 
 ### `bl config ui`
 
-| Field           | Value                                         |
-| --------------- | --------------------------------------------- |
-| **Name**        | `config ui`                                   |
-| **Description** | Open a local web UI to manage config profiles |
-| **Usage**       | `bl config ui [--port <port>] [--no-open]`    |
+| Field              | Value                                         |
+| ------------------ | --------------------------------------------- |
+| **Name**           | `config ui`                                   |
+| **Description**    | Open a local web UI to manage config profiles |
+| **Authentication** | No Auth                                       |
+| **Usage**          | `bl config ui [--port <port>] [--no-open]`    |
 
 #### Flags
 
@@ -157,11 +162,12 @@ bl config ui --no-open
 
 ### `bl config use`
 
-| Field           | Value                         |
-| --------------- | ----------------------------- |
-| **Name**        | `config use`                  |
-| **Description** | Set the active config profile |
-| **Usage**       | `bl config use --name <name>` |
+| Field              | Value                         |
+| ------------------ | ----------------------------- |
+| **Name**           | `config use`                  |
+| **Description**    | Set the active config profile |
+| **Authentication** | No Auth                       |
+| **Usage**          | `bl config use --name <name>` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/console.md
+++ b/skills/bailian-cli/reference/console.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command           | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `bl console call` | Call a Bailian console API via the CLI gateway |
+| Command           | Authentication | Description                                    |
+| ----------------- | -------------- | ---------------------------------------------- |
+| `bl console call` | Console        | Call a Bailian console API via the CLI gateway |
 
 ## Command details
 
 ### `bl console call`
 
-| Field           | Value                                               |
-| --------------- | --------------------------------------------------- |
-| **Name**        | `console call`                                      |
-| **Description** | Call a Bailian console API via the CLI gateway      |
-| **Usage**       | `bl console call --api <api> --data <json> [flags]` |
+| Field              | Value                                               |
+| ------------------ | --------------------------------------------------- |
+| **Name**           | `console call`                                      |
+| **Description**    | Call a Bailian console API via the CLI gateway      |
+| **Authentication** | Console                                             |
+| **Usage**          | `bl console call --api <api> --data <json> [flags]` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/file.md
+++ b/skills/bailian-cli/reference/file.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command          | Description                                              |
-| ---------------- | -------------------------------------------------------- |
-| `bl file upload` | Upload a local file to DashScope temporary storage (48h) |
+| Command          | Authentication | Description                                              |
+| ---------------- | -------------- | -------------------------------------------------------- |
+| `bl file upload` | API Key        | Upload a local file to DashScope temporary storage (48h) |
 
 ## Command details
 
 ### `bl file upload`
 
-| Field           | Value                                                    |
-| --------------- | -------------------------------------------------------- |
-| **Name**        | `file upload`                                            |
-| **Description** | Upload a local file to DashScope temporary storage (48h) |
-| **Usage**       | `bl file upload --file <path> --model <model>`           |
+| Field              | Value                                                    |
+| ------------------ | -------------------------------------------------------- |
+| **Name**           | `file upload`                                            |
+| **Description**    | Upload a local file to DashScope temporary storage (48h) |
+| **Authentication** | API Key                                                  |
+| **Usage**          | `bl file upload --file <path> --model <model>`           |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/index.md
+++ b/skills/bailian-cli/reference/index.md
@@ -9,65 +9,65 @@ Use this index for the skill-scoped quick index and global flags.
 
 ## Quick index
 
-| Command                         | Description                                                                                    | Detail                         |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------ |
-| `bl advisor recommend`          | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) | [advisor.md](advisor.md)       |
-| `bl app call`                   | Call a Bailian application (agent or workflow)                                                 | [app.md](app.md)               |
-| `bl app list`                   | List Bailian applications                                                                      | [app.md](app.md)               |
-| `bl auth generate-access-token` | Generate a CLI access token using OpenAPI AK/SK                                                | [auth.md](auth.md)             |
-| `bl auth login`                 | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist)   | [auth.md](auth.md)             |
-| `bl auth logout`                | Clear stored credentials; full logout also clears the model Base URL                           | [auth.md](auth.md)             |
-| `bl auth status`                | Show current authentication state                                                              | [auth.md](auth.md)             |
-| `bl config agent`               | Configure a coding agent to use DashScope API                                                  | [config.md](config.md)         |
-| `bl config list`                | List config profiles and show the active profile                                               | [config.md](config.md)         |
-| `bl config set`                 | Set a config value                                                                             | [config.md](config.md)         |
-| `bl config show`                | Display current configuration                                                                  | [config.md](config.md)         |
-| `bl config ui`                  | Open a local web UI to manage config profiles                                                  | [config.md](config.md)         |
-| `bl config use`                 | Set the active config profile                                                                  | [config.md](config.md)         |
-| `bl console call`               | Call a Bailian console API via the CLI gateway                                                 | [console.md](console.md)       |
-| `bl file upload`                | Upload a local file to DashScope temporary storage (48h)                                       | [file.md](file.md)             |
-| `bl knowledge chat`             | Chat with a Bailian knowledge base (RAG Q&A with streaming)                                    | [knowledge.md](knowledge.md)   |
-| `bl knowledge retrieve`         | Retrieve from a Bailian knowledge base (deprecated, use `search` instead)                      | [knowledge.md](knowledge.md)   |
-| `bl knowledge search`           | Search a Bailian knowledge base (RAG semantic retrieval)                                       | [knowledge.md](knowledge.md)   |
-| `bl mcp call`                   | Call a tool on an MCP server (tools/call)                                                      | [mcp.md](mcp.md)               |
-| `bl mcp list`                   | List MCP servers activated under your Bailian account                                          | [mcp.md](mcp.md)               |
-| `bl mcp tools`                  | List tools exposed by an MCP server (tools/list)                                               | [mcp.md](mcp.md)               |
-| `bl memory add`                 | Add memory from messages or custom content                                                     | [memory.md](memory.md)         |
-| `bl memory delete`              | Delete a memory node                                                                           | [memory.md](memory.md)         |
-| `bl memory list`                | List memory nodes for a user                                                                   | [memory.md](memory.md)         |
-| `bl memory profile create`      | Create a user profile schema for memory profiling                                              | [memory.md](memory.md)         |
-| `bl memory profile get`         | Get user profile by schema ID and user ID                                                      | [memory.md](memory.md)         |
-| `bl memory search`              | Search memory nodes by query or messages                                                       | [memory.md](memory.md)         |
-| `bl memory update`              | Update a memory node content                                                                   | [memory.md](memory.md)         |
-| `bl model list`                 | Browse model families or show detailed model info in the Bailian model marketplace             | [model.md](model.md)           |
-| `bl pipeline run`               | Run a pipeline workflow definition                                                             | [pipeline.md](pipeline.md)     |
-| `bl pipeline validate`          | Validate a pipeline definition without executing                                               | [pipeline.md](pipeline.md)     |
-| `bl plugin install`             | Install or upgrade an allowlisted Command Pack                                                 | [plugin.md](plugin.md)         |
-| `bl plugin link`                | Link an allowlisted local Command Pack for development                                         | [plugin.md](plugin.md)         |
-| `bl plugin list`                | List installed Command Packs and their load status                                             | [plugin.md](plugin.md)         |
-| `bl plugin remove`              | Remove an installed Command Pack                                                               | [plugin.md](plugin.md)         |
-| `bl quota check`                | Check current usage against rate limits                                                        | [quota.md](quota.md)           |
-| `bl quota history`              | View quota change history                                                                      | [quota.md](quota.md)           |
-| `bl quota list`                 | View model RPM/TPM rate limits                                                                 | [quota.md](quota.md)           |
-| `bl quota request`              | Request a temporary quota increase                                                             | [quota.md](quota.md)           |
-| `bl search web`                 | Search the web using DashScope MCP WebSearch service                                           | [search.md](search.md)         |
-| `bl skill add`                  | Install skills from the Bailian skill registry into local agents                               | [skill.md](skill.md)           |
-| `bl skill init`                 | Install all bailian-\* skills (one-shot bootstrap for new environments)                        | [skill.md](skill.md)           |
-| `bl skill list`                 | List registry skills and diff against local installs                                           | [skill.md](skill.md)           |
-| `bl skill remove`               | Remove locally installed skills (registry is untouched)                                        | [skill.md](skill.md)           |
-| `bl skill update`               | Update installed skills to the latest registry versions                                        | [skill.md](skill.md)           |
-| `bl text chat`                  | Send a chat completion (OpenAI compatible, DashScope)                                          | [text.md](text.md)             |
-| `bl token-plan add-member`      | Add a member to a Token Plan organization                                                      | [token-plan.md](token-plan.md) |
-| `bl token-plan assign-seats`    | Batch assign Token Plan seats to members                                                       | [token-plan.md](token-plan.md) |
-| `bl token-plan create-key`      | Create a Token Plan API key for a seat                                                         | [token-plan.md](token-plan.md) |
-| `bl token-plan list-seats`      | List Token Plan subscription seat details                                                      | [token-plan.md](token-plan.md) |
-| `bl update`                     | Update the CLI to the latest or a specified version                                            | [update.md](update.md)         |
-| `bl usage free`                 | Query free-tier quota for models (all models if --model is omitted)                            | [usage.md](usage.md)           |
-| `bl usage freetier`             | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable     | [usage.md](usage.md)           |
-| `bl usage stats`                | Query model usage statistics                                                                   | [usage.md](usage.md)           |
-| `bl usage summary`              | Show a unified usage summary: free-tier quota and recent usage overview                        | [usage.md](usage.md)           |
-| `bl workspace init`             | Initialize Bailian workspace and activate postpaid services                                    | [workspace.md](workspace.md)   |
-| `bl workspace list`             | List all workspaces                                                                            | [workspace.md](workspace.md)   |
+| Command                         | Authentication | Description                                                                                    | Detail                         |
+| ------------------------------- | -------------- | ---------------------------------------------------------------------------------------------- | ------------------------------ |
+| `bl advisor recommend`          | API Key        | Recommend the best models for your use case (intent analysis → candidate recall → LLM ranking) | [advisor.md](advisor.md)       |
+| `bl app call`                   | API Key        | Call a Bailian application (agent or workflow)                                                 | [app.md](app.md)               |
+| `bl app list`                   | Console        | List Bailian applications                                                                      | [app.md](app.md)               |
+| `bl auth generate-access-token` | No Auth        | Generate a CLI access token using OpenAPI AK/SK                                                | [auth.md](auth.md)             |
+| `bl auth login`                 | No Auth        | Authenticate with API key, console browser login, or OpenAPI AK/SK (credentials can coexist)   | [auth.md](auth.md)             |
+| `bl auth logout`                | No Auth        | Clear stored credentials; full logout also clears the model Base URL                           | [auth.md](auth.md)             |
+| `bl auth status`                | No Auth        | Show current authentication state                                                              | [auth.md](auth.md)             |
+| `bl config agent`               | No Auth        | Configure a coding agent to use DashScope API                                                  | [config.md](config.md)         |
+| `bl config list`                | No Auth        | List config profiles and show the active profile                                               | [config.md](config.md)         |
+| `bl config set`                 | No Auth        | Set a config value                                                                             | [config.md](config.md)         |
+| `bl config show`                | No Auth        | Display current configuration                                                                  | [config.md](config.md)         |
+| `bl config ui`                  | No Auth        | Open a local web UI to manage config profiles                                                  | [config.md](config.md)         |
+| `bl config use`                 | No Auth        | Set the active config profile                                                                  | [config.md](config.md)         |
+| `bl console call`               | Console        | Call a Bailian console API via the CLI gateway                                                 | [console.md](console.md)       |
+| `bl file upload`                | API Key        | Upload a local file to DashScope temporary storage (48h)                                       | [file.md](file.md)             |
+| `bl knowledge chat`             | API Key        | Chat with a Bailian knowledge base (RAG Q&A with streaming)                                    | [knowledge.md](knowledge.md)   |
+| `bl knowledge retrieve`         | API Key        | Retrieve from a Bailian knowledge base (deprecated, use `search` instead)                      | [knowledge.md](knowledge.md)   |
+| `bl knowledge search`           | API Key        | Search a Bailian knowledge base (RAG semantic retrieval)                                       | [knowledge.md](knowledge.md)   |
+| `bl mcp call`                   | API Key        | Call a tool on an MCP server (tools/call)                                                      | [mcp.md](mcp.md)               |
+| `bl mcp list`                   | Console        | List MCP servers activated under your Bailian account                                          | [mcp.md](mcp.md)               |
+| `bl mcp tools`                  | API Key        | List tools exposed by an MCP server (tools/list)                                               | [mcp.md](mcp.md)               |
+| `bl memory add`                 | API Key        | Add memory from messages or custom content                                                     | [memory.md](memory.md)         |
+| `bl memory delete`              | API Key        | Delete a memory node                                                                           | [memory.md](memory.md)         |
+| `bl memory list`                | API Key        | List memory nodes for a user                                                                   | [memory.md](memory.md)         |
+| `bl memory profile create`      | API Key        | Create a user profile schema for memory profiling                                              | [memory.md](memory.md)         |
+| `bl memory profile get`         | API Key        | Get user profile by schema ID and user ID                                                      | [memory.md](memory.md)         |
+| `bl memory search`              | API Key        | Search memory nodes by query or messages                                                       | [memory.md](memory.md)         |
+| `bl memory update`              | API Key        | Update a memory node content                                                                   | [memory.md](memory.md)         |
+| `bl model list`                 | Console        | Browse model families or show detailed model info in the Bailian model marketplace             | [model.md](model.md)           |
+| `bl pipeline run`               | No Auth        | Run a pipeline workflow definition                                                             | [pipeline.md](pipeline.md)     |
+| `bl pipeline validate`          | No Auth        | Validate a pipeline definition without executing                                               | [pipeline.md](pipeline.md)     |
+| `bl plugin install`             | No Auth        | Install or upgrade an allowlisted Command Pack                                                 | [plugin.md](plugin.md)         |
+| `bl plugin link`                | No Auth        | Link an allowlisted local Command Pack for development                                         | [plugin.md](plugin.md)         |
+| `bl plugin list`                | No Auth        | List installed Command Packs and their load status                                             | [plugin.md](plugin.md)         |
+| `bl plugin remove`              | No Auth        | Remove an installed Command Pack                                                               | [plugin.md](plugin.md)         |
+| `bl quota check`                | Console        | Check current usage against rate limits                                                        | [quota.md](quota.md)           |
+| `bl quota history`              | Console        | View quota change history                                                                      | [quota.md](quota.md)           |
+| `bl quota list`                 | Console        | View model RPM/TPM rate limits                                                                 | [quota.md](quota.md)           |
+| `bl quota request`              | Console        | Request a temporary quota increase                                                             | [quota.md](quota.md)           |
+| `bl search web`                 | API Key        | Search the web using DashScope MCP WebSearch service                                           | [search.md](search.md)         |
+| `bl skill add`                  | No Auth        | Install skills from the Bailian skill registry into local agents                               | [skill.md](skill.md)           |
+| `bl skill init`                 | No Auth        | Install all bailian-\* skills (one-shot bootstrap for new environments)                        | [skill.md](skill.md)           |
+| `bl skill list`                 | No Auth        | List registry skills and diff against local installs                                           | [skill.md](skill.md)           |
+| `bl skill remove`               | No Auth        | Remove locally installed skills (registry is untouched)                                        | [skill.md](skill.md)           |
+| `bl skill update`               | No Auth        | Update installed skills to the latest registry versions                                        | [skill.md](skill.md)           |
+| `bl text chat`                  | API Key        | Send a chat completion (OpenAI compatible, DashScope)                                          | [text.md](text.md)             |
+| `bl token-plan add-member`      | AK/SK          | Add a member to a Token Plan organization                                                      | [token-plan.md](token-plan.md) |
+| `bl token-plan assign-seats`    | AK/SK          | Batch assign Token Plan seats to members                                                       | [token-plan.md](token-plan.md) |
+| `bl token-plan create-key`      | AK/SK          | Create a Token Plan API key for a seat                                                         | [token-plan.md](token-plan.md) |
+| `bl token-plan list-seats`      | AK/SK          | List Token Plan subscription seat details                                                      | [token-plan.md](token-plan.md) |
+| `bl update`                     | No Auth        | Update the CLI to the latest or a specified version                                            | [update.md](update.md)         |
+| `bl usage free`                 | Console        | Query free-tier quota for models (all models if --model is omitted)                            | [usage.md](usage.md)           |
+| `bl usage freetier`             | Console        | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable     | [usage.md](usage.md)           |
+| `bl usage stats`                | Console        | Query model usage statistics                                                                   | [usage.md](usage.md)           |
+| `bl usage summary`              | Console        | Show a unified usage summary: free-tier quota and recent usage overview                        | [usage.md](usage.md)           |
+| `bl workspace init`             | No Auth        | Initialize Bailian workspace and activate postpaid services                                    | [workspace.md](workspace.md)   |
+| `bl workspace list`             | Console        | List all workspaces                                                                            | [workspace.md](workspace.md)   |
 
 ## By group
 

--- a/skills/bailian-cli/reference/knowledge.md
+++ b/skills/bailian-cli/reference/knowledge.md
@@ -7,21 +7,22 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                 | Description                                                               |
-| ----------------------- | ------------------------------------------------------------------------- |
-| `bl knowledge chat`     | Chat with a Bailian knowledge base (RAG Q&A with streaming)               |
-| `bl knowledge retrieve` | Retrieve from a Bailian knowledge base (deprecated, use `search` instead) |
-| `bl knowledge search`   | Search a Bailian knowledge base (RAG semantic retrieval)                  |
+| Command                 | Authentication | Description                                                               |
+| ----------------------- | -------------- | ------------------------------------------------------------------------- |
+| `bl knowledge chat`     | API Key        | Chat with a Bailian knowledge base (RAG Q&A with streaming)               |
+| `bl knowledge retrieve` | API Key        | Retrieve from a Bailian knowledge base (deprecated, use `search` instead) |
+| `bl knowledge search`   | API Key        | Search a Bailian knowledge base (RAG semantic retrieval)                  |
 
 ## Command details
 
 ### `bl knowledge chat`
 
-| Field           | Value                                                        |
-| --------------- | ------------------------------------------------------------ |
-| **Name**        | `knowledge chat`                                             |
-| **Description** | Chat with a Bailian knowledge base (RAG Q&A with streaming)  |
-| **Usage**       | `bl knowledge chat --message <text> --agent-id <id> [flags]` |
+| Field              | Value                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| **Name**           | `knowledge chat`                                             |
+| **Description**    | Chat with a Bailian knowledge base (RAG Q&A with streaming)  |
+| **Authentication** | API Key                                                      |
+| **Usage**          | `bl knowledge chat --message <text> --agent-id <id> [flags]` |
 
 #### Flags
 
@@ -57,11 +58,12 @@ bl knowledge chat --message "Describe these images" --image https://example.com/
 
 ### `bl knowledge retrieve`
 
-| Field           | Value                                                                     |
-| --------------- | ------------------------------------------------------------------------- |
-| **Name**        | `knowledge retrieve`                                                      |
-| **Description** | Retrieve from a Bailian knowledge base (deprecated, use `search` instead) |
-| **Usage**       | `bl knowledge retrieve --index-id <id> --query <text> [flags]`            |
+| Field              | Value                                                                     |
+| ------------------ | ------------------------------------------------------------------------- |
+| **Name**           | `knowledge retrieve`                                                      |
+| **Description**    | Retrieve from a Bailian knowledge base (deprecated, use `search` instead) |
+| **Authentication** | API Key                                                                   |
+| **Usage**          | `bl knowledge retrieve --index-id <id> --query <text> [flags]`            |
 
 #### Flags
 
@@ -92,11 +94,12 @@ bl knowledge retrieve --index-id idx_xxx --query "RAG retrieval" --rerank --rera
 
 ### `bl knowledge search`
 
-| Field           | Value                                                        |
-| --------------- | ------------------------------------------------------------ |
-| **Name**        | `knowledge search`                                           |
-| **Description** | Search a Bailian knowledge base (RAG semantic retrieval)     |
-| **Usage**       | `bl knowledge search --query <text> --agent-id <id> [flags]` |
+| Field              | Value                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| **Name**           | `knowledge search`                                           |
+| **Description**    | Search a Bailian knowledge base (RAG semantic retrieval)     |
+| **Authentication** | API Key                                                      |
+| **Usage**          | `bl knowledge search --query <text> --agent-id <id> [flags]` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/mcp.md
+++ b/skills/bailian-cli/reference/mcp.md
@@ -7,21 +7,22 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command        | Description                                           |
-| -------------- | ----------------------------------------------------- |
-| `bl mcp call`  | Call a tool on an MCP server (tools/call)             |
-| `bl mcp list`  | List MCP servers activated under your Bailian account |
-| `bl mcp tools` | List tools exposed by an MCP server (tools/list)      |
+| Command        | Authentication | Description                                           |
+| -------------- | -------------- | ----------------------------------------------------- |
+| `bl mcp call`  | API Key        | Call a tool on an MCP server (tools/call)             |
+| `bl mcp list`  | Console        | List MCP servers activated under your Bailian account |
+| `bl mcp tools` | API Key        | List tools exposed by an MCP server (tools/list)      |
 
 ## Command details
 
 ### `bl mcp call`
 
-| Field           | Value                                                                               |
-| --------------- | ----------------------------------------------------------------------------------- |
-| **Name**        | `mcp call`                                                                          |
-| **Description** | Call a tool on an MCP server (tools/call)                                           |
-| **Usage**       | `bl mcp call --target <server.tool> [--arg k=v ...] [--json '{...}'] [--url <url>]` |
+| Field              | Value                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| **Name**           | `mcp call`                                                                          |
+| **Description**    | Call a tool on an MCP server (tools/call)                                           |
+| **Authentication** | API Key                                                                             |
+| **Usage**          | `bl mcp call --target <server.tool> [--arg k=v ...] [--json '{...}'] [--url <url>]` |
 
 #### Flags
 
@@ -51,11 +52,12 @@ bl mcp call --target market-cmapi00073529.SmartFundSelection --arg riskLevel=R3 
 
 ### `bl mcp list`
 
-| Field           | Value                                                 |
-| --------------- | ----------------------------------------------------- |
-| **Name**        | `mcp list`                                            |
-| **Description** | List MCP servers activated under your Bailian account |
-| **Usage**       | `bl mcp list [flags]`                                 |
+| Field              | Value                                                 |
+| ------------------ | ----------------------------------------------------- |
+| **Name**           | `mcp list`                                            |
+| **Description**    | List MCP servers activated under your Bailian account |
+| **Authentication** | Console                                               |
+| **Usage**          | `bl mcp list [flags]`                                 |
 
 #### Flags
 
@@ -86,11 +88,12 @@ bl mcp list --output json
 
 ### `bl mcp tools`
 
-| Field           | Value                                            |
-| --------------- | ------------------------------------------------ |
-| **Name**        | `mcp tools`                                      |
-| **Description** | List tools exposed by an MCP server (tools/list) |
-| **Usage**       | `bl mcp tools --server <code> [--url <url>]`     |
+| Field              | Value                                            |
+| ------------------ | ------------------------------------------------ |
+| **Name**           | `mcp tools`                                      |
+| **Description**    | List tools exposed by an MCP server (tools/list) |
+| **Authentication** | API Key                                          |
+| **Usage**          | `bl mcp tools --server <code> [--url <url>]`     |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/memory.md
+++ b/skills/bailian-cli/reference/memory.md
@@ -7,25 +7,26 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                    | Description                                       |
-| -------------------------- | ------------------------------------------------- |
-| `bl memory add`            | Add memory from messages or custom content        |
-| `bl memory delete`         | Delete a memory node                              |
-| `bl memory list`           | List memory nodes for a user                      |
-| `bl memory profile create` | Create a user profile schema for memory profiling |
-| `bl memory profile get`    | Get user profile by schema ID and user ID         |
-| `bl memory search`         | Search memory nodes by query or messages          |
-| `bl memory update`         | Update a memory node content                      |
+| Command                    | Authentication | Description                                       |
+| -------------------------- | -------------- | ------------------------------------------------- |
+| `bl memory add`            | API Key        | Add memory from messages or custom content        |
+| `bl memory delete`         | API Key        | Delete a memory node                              |
+| `bl memory list`           | API Key        | List memory nodes for a user                      |
+| `bl memory profile create` | API Key        | Create a user profile schema for memory profiling |
+| `bl memory profile get`    | API Key        | Get user profile by schema ID and user ID         |
+| `bl memory search`         | API Key        | Search memory nodes by query or messages          |
+| `bl memory update`         | API Key        | Update a memory node content                      |
 
 ## Command details
 
 ### `bl memory add`
 
-| Field           | Value                                                                         |
-| --------------- | ----------------------------------------------------------------------------- |
-| **Name**        | `memory add`                                                                  |
-| **Description** | Add memory from messages or custom content                                    |
-| **Usage**       | `bl memory add --user-id <id> [--messages <json>] [--content <text>] [flags]` |
+| Field              | Value                                                                         |
+| ------------------ | ----------------------------------------------------------------------------- |
+| **Name**           | `memory add`                                                                  |
+| **Description**    | Add memory from messages or custom content                                    |
+| **Authentication** | API Key                                                                       |
+| **Usage**          | `bl memory add --user-id <id> [--messages <json>] [--content <text>] [flags]` |
 
 #### Flags
 
@@ -55,11 +56,12 @@ bl memory add --user-id user1 --content "Lives in Beijing" --profile-schema sche
 
 ### `bl memory delete`
 
-| Field           | Value                                            |
-| --------------- | ------------------------------------------------ |
-| **Name**        | `memory delete`                                  |
-| **Description** | Delete a memory node                             |
-| **Usage**       | `bl memory delete --node-id <id> --user-id <id>` |
+| Field              | Value                                            |
+| ------------------ | ------------------------------------------------ |
+| **Name**           | `memory delete`                                  |
+| **Description**    | Delete a memory node                             |
+| **Authentication** | API Key                                          |
+| **Usage**          | `bl memory delete --node-id <id> --user-id <id>` |
 
 #### Flags
 
@@ -79,11 +81,12 @@ bl memory delete --node-id node_xxx --user-id user1
 
 ### `bl memory list`
 
-| Field           | Value                                   |
-| --------------- | --------------------------------------- |
-| **Name**        | `memory list`                           |
-| **Description** | List memory nodes for a user            |
-| **Usage**       | `bl memory list --user-id <id> [flags]` |
+| Field              | Value                                   |
+| ------------------ | --------------------------------------- |
+| **Name**           | `memory list`                           |
+| **Description**    | List memory nodes for a user            |
+| **Authentication** | API Key                                 |
+| **Usage**          | `bl memory list --user-id <id> [flags]` |
 
 #### Flags
 
@@ -108,11 +111,12 @@ bl memory list --user-id user1 --page-size 20 --page 2
 
 ### `bl memory profile create`
 
-| Field           | Value                                                                |
-| --------------- | -------------------------------------------------------------------- |
-| **Name**        | `memory profile create`                                              |
-| **Description** | Create a user profile schema for memory profiling                    |
-| **Usage**       | `bl memory profile create --name <name> --attributes <json> [flags]` |
+| Field              | Value                                                                |
+| ------------------ | -------------------------------------------------------------------- |
+| **Name**           | `memory profile create`                                              |
+| **Description**    | Create a user profile schema for memory profiling                    |
+| **Authentication** | API Key                                                              |
+| **Usage**          | `bl memory profile create --name <name> --attributes <json> [flags]` |
 
 #### Flags
 
@@ -132,11 +136,12 @@ bl memory profile create --name "user_basic" --attributes '[{"name":"age","descr
 
 ### `bl memory profile get`
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| **Name**        | `memory profile get`                                    |
-| **Description** | Get user profile by schema ID and user ID               |
-| **Usage**       | `bl memory profile get --schema-id <id> --user-id <id>` |
+| Field              | Value                                                   |
+| ------------------ | ------------------------------------------------------- |
+| **Name**           | `memory profile get`                                    |
+| **Description**    | Get user profile by schema ID and user ID               |
+| **Authentication** | API Key                                                 |
+| **Usage**          | `bl memory profile get --schema-id <id> --user-id <id>` |
 
 #### Flags
 
@@ -155,11 +160,12 @@ bl memory profile get --schema-id schema_xxx --user-id user1
 
 ### `bl memory search`
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| **Name**        | `memory search`                                            |
-| **Description** | Search memory nodes by query or messages                   |
-| **Usage**       | `bl memory search --user-id <id> [--query <text>] [flags]` |
+| Field              | Value                                                      |
+| ------------------ | ---------------------------------------------------------- |
+| **Name**           | `memory search`                                            |
+| **Description**    | Search memory nodes by query or messages                   |
+| **Authentication** | API Key                                                    |
+| **Usage**          | `bl memory search --user-id <id> [--query <text>] [flags]` |
 
 #### Flags
 
@@ -185,11 +191,12 @@ bl memory search --user-id user1 --messages '[{"role":"user","content":"recommen
 
 ### `bl memory update`
 
-| Field           | Value                                                             |
-| --------------- | ----------------------------------------------------------------- |
-| **Name**        | `memory update`                                                   |
-| **Description** | Update a memory node content                                      |
-| **Usage**       | `bl memory update --node-id <id> --user-id <id> --content <text>` |
+| Field              | Value                                                             |
+| ------------------ | ----------------------------------------------------------------- |
+| **Name**           | `memory update`                                                   |
+| **Description**    | Update a memory node content                                      |
+| **Authentication** | API Key                                                           |
+| **Usage**          | `bl memory update --node-id <id> --user-id <id> --content <text>` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/model.md
+++ b/skills/bailian-cli/reference/model.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command         | Description                                                                        |
-| --------------- | ---------------------------------------------------------------------------------- |
-| `bl model list` | Browse model families or show detailed model info in the Bailian model marketplace |
+| Command         | Authentication | Description                                                                        |
+| --------------- | -------------- | ---------------------------------------------------------------------------------- |
+| `bl model list` | Console        | Browse model families or show detailed model info in the Bailian model marketplace |
 
 ## Command details
 
 ### `bl model list`
 
-| Field           | Value                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `model list`                                                                                                                    |
-| **Description** | Browse model families or show detailed model info in the Bailian model marketplace                                              |
-| **Usage**       | `bl model list [--model <model>] [--page <n>] [--page-size <n>] [--provider <p>] [--capability <c>] [--feature <f>] [--enrich]` |
+| Field              | Value                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `model list`                                                                                                                    |
+| **Description**    | Browse model families or show detailed model info in the Bailian model marketplace                                              |
+| **Authentication** | Console                                                                                                                         |
+| **Usage**          | `bl model list [--model <model>] [--page <n>] [--page-size <n>] [--provider <p>] [--capability <c>] [--feature <f>] [--enrich]` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/pipeline.md
+++ b/skills/bailian-cli/reference/pipeline.md
@@ -7,20 +7,21 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                | Description                                      |
-| ---------------------- | ------------------------------------------------ |
-| `bl pipeline run`      | Run a pipeline workflow definition               |
-| `bl pipeline validate` | Validate a pipeline definition without executing |
+| Command                | Authentication | Description                                      |
+| ---------------------- | -------------- | ------------------------------------------------ |
+| `bl pipeline run`      | No Auth        | Run a pipeline workflow definition               |
+| `bl pipeline validate` | No Auth        | Validate a pipeline definition without executing |
 
 ## Command details
 
 ### `bl pipeline run`
 
-| Field           | Value                                   |
-| --------------- | --------------------------------------- |
-| **Name**        | `pipeline run`                          |
-| **Description** | Run a pipeline workflow definition      |
-| **Usage**       | `bl pipeline run --file <path> [flags]` |
+| Field              | Value                                   |
+| ------------------ | --------------------------------------- |
+| **Name**           | `pipeline run`                          |
+| **Description**    | Run a pipeline workflow definition      |
+| **Authentication** | No Auth                                 |
+| **Usage**          | `bl pipeline run --file <path> [flags]` |
 
 #### Flags
 
@@ -57,11 +58,12 @@ bl pipeline run --file workflow.yaml --output json
 
 ### `bl pipeline validate`
 
-| Field           | Value                                            |
-| --------------- | ------------------------------------------------ |
-| **Name**        | `pipeline validate`                              |
-| **Description** | Validate a pipeline definition without executing |
-| **Usage**       | `bl pipeline validate --file <path>`             |
+| Field              | Value                                            |
+| ------------------ | ------------------------------------------------ |
+| **Name**           | `pipeline validate`                              |
+| **Description**    | Validate a pipeline definition without executing |
+| **Authentication** | No Auth                                          |
+| **Usage**          | `bl pipeline validate --file <path>`             |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/plugin.md
+++ b/skills/bailian-cli/reference/plugin.md
@@ -7,22 +7,23 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command             | Description                                            |
-| ------------------- | ------------------------------------------------------ |
-| `bl plugin install` | Install or upgrade an allowlisted Command Pack         |
-| `bl plugin link`    | Link an allowlisted local Command Pack for development |
-| `bl plugin list`    | List installed Command Packs and their load status     |
-| `bl plugin remove`  | Remove an installed Command Pack                       |
+| Command             | Authentication | Description                                            |
+| ------------------- | -------------- | ------------------------------------------------------ |
+| `bl plugin install` | No Auth        | Install or upgrade an allowlisted Command Pack         |
+| `bl plugin link`    | No Auth        | Link an allowlisted local Command Pack for development |
+| `bl plugin list`    | No Auth        | List installed Command Packs and their load status     |
+| `bl plugin remove`  | No Auth        | Remove an installed Command Pack                       |
 
 ## Command details
 
 ### `bl plugin install`
 
-| Field           | Value                                          |
-| --------------- | ---------------------------------------------- |
-| **Name**        | `plugin install`                               |
-| **Description** | Install or upgrade an allowlisted Command Pack |
-| **Usage**       | `bl plugin install --package <name[@version]>` |
+| Field              | Value                                          |
+| ------------------ | ---------------------------------------------- |
+| **Name**           | `plugin install`                               |
+| **Description**    | Install or upgrade an allowlisted Command Pack |
+| **Authentication** | No Auth                                        |
+| **Usage**          | `bl plugin install --package <name[@version]>` |
 
 #### Flags
 
@@ -42,11 +43,12 @@ bl plugin install --package @ali/bailian-plugin-agent@beta
 
 ### `bl plugin link`
 
-| Field           | Value                                                  |
-| --------------- | ------------------------------------------------------ |
-| **Name**        | `plugin link`                                          |
-| **Description** | Link an allowlisted local Command Pack for development |
-| **Usage**       | `bl plugin link --path <directory>`                    |
+| Field              | Value                                                  |
+| ------------------ | ------------------------------------------------------ |
+| **Name**           | `plugin link`                                          |
+| **Description**    | Link an allowlisted local Command Pack for development |
+| **Authentication** | No Auth                                                |
+| **Usage**          | `bl plugin link --path <directory>`                    |
 
 #### Flags
 
@@ -62,11 +64,12 @@ bl plugin link --path ../bailian-plugin-agent
 
 ### `bl plugin list`
 
-| Field           | Value                                              |
-| --------------- | -------------------------------------------------- |
-| **Name**        | `plugin list`                                      |
-| **Description** | List installed Command Packs and their load status |
-| **Usage**       | `bl plugin list`                                   |
+| Field              | Value                                              |
+| ------------------ | -------------------------------------------------- |
+| **Name**           | `plugin list`                                      |
+| **Description**    | List installed Command Packs and their load status |
+| **Authentication** | No Auth                                            |
+| **Usage**          | `bl plugin list`                                   |
 
 #### Flags
 
@@ -84,11 +87,12 @@ bl plugin list --output json
 
 ### `bl plugin remove`
 
-| Field           | Value                               |
-| --------------- | ----------------------------------- |
-| **Name**        | `plugin remove`                     |
-| **Description** | Remove an installed Command Pack    |
-| **Usage**       | `bl plugin remove --name <package>` |
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| **Name**           | `plugin remove`                     |
+| **Description**    | Remove an installed Command Pack    |
+| **Authentication** | No Auth                             |
+| **Usage**          | `bl plugin remove --name <package>` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/quota.md
+++ b/skills/bailian-cli/reference/quota.md
@@ -7,22 +7,23 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command            | Description                             |
-| ------------------ | --------------------------------------- |
-| `bl quota check`   | Check current usage against rate limits |
-| `bl quota history` | View quota change history               |
-| `bl quota list`    | View model RPM/TPM rate limits          |
-| `bl quota request` | Request a temporary quota increase      |
+| Command            | Authentication | Description                             |
+| ------------------ | -------------- | --------------------------------------- |
+| `bl quota check`   | Console        | Check current usage against rate limits |
+| `bl quota history` | Console        | View quota change history               |
+| `bl quota list`    | Console        | View model RPM/TPM rate limits          |
+| `bl quota request` | Console        | Request a temporary quota increase      |
 
 ## Command details
 
 ### `bl quota check`
 
-| Field           | Value                                      |
-| --------------- | ------------------------------------------ |
-| **Name**        | `quota check`                              |
-| **Description** | Check current usage against rate limits    |
-| **Usage**       | `bl quota check [--model <model>] [flags]` |
+| Field              | Value                                      |
+| ------------------ | ------------------------------------------ |
+| **Name**           | `quota check`                              |
+| **Description**    | Check current usage against rate limits    |
+| **Authentication** | Console                                    |
+| **Usage**          | `bl quota check [--model <model>] [flags]` |
 
 #### Flags
 
@@ -59,11 +60,12 @@ bl quota check --output json
 
 ### `bl quota history`
 
-| Field           | Value                      |
-| --------------- | -------------------------- |
-| **Name**        | `quota history`            |
-| **Description** | View quota change history  |
-| **Usage**       | `bl quota history [flags]` |
+| Field              | Value                      |
+| ------------------ | -------------------------- |
+| **Name**           | `quota history`            |
+| **Description**    | View quota change history  |
+| **Authentication** | Console                    |
+| **Usage**          | `bl quota history [flags]` |
 
 #### Flags
 
@@ -101,11 +103,12 @@ bl quota history --output json
 
 ### `bl quota list`
 
-| Field           | Value                                     |
-| --------------- | ----------------------------------------- |
-| **Name**        | `quota list`                              |
-| **Description** | View model RPM/TPM rate limits            |
-| **Usage**       | `bl quota list [--model <model>] [flags]` |
+| Field              | Value                                     |
+| ------------------ | ----------------------------------------- |
+| **Name**           | `quota list`                              |
+| **Description**    | View model RPM/TPM rate limits            |
+| **Authentication** | Console                                   |
+| **Usage**          | `bl quota list [--model <model>] [flags]` |
 
 #### Flags
 
@@ -137,11 +140,12 @@ bl quota list --output json
 
 ### `bl quota request`
 
-| Field           | Value                                                    |
-| --------------- | -------------------------------------------------------- |
-| **Name**        | `quota request`                                          |
-| **Description** | Request a temporary quota increase                       |
-| **Usage**       | `bl quota request --model <model> --tpm <value> [flags]` |
+| Field              | Value                                                    |
+| ------------------ | -------------------------------------------------------- |
+| **Name**           | `quota request`                                          |
+| **Description**    | Request a temporary quota increase                       |
+| **Authentication** | Console                                                  |
+| **Usage**          | `bl quota request --model <model> --tpm <value> [flags]` |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/search.md
+++ b/skills/bailian-cli/reference/search.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command         | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `bl search web` | Search the web using DashScope MCP WebSearch service |
+| Command         | Authentication | Description                                          |
+| --------------- | -------------- | ---------------------------------------------------- |
+| `bl search web` | API Key        | Search the web using DashScope MCP WebSearch service |
 
 ## Command details
 
 ### `bl search web`
 
-| Field           | Value                                                |
-| --------------- | ---------------------------------------------------- |
-| **Name**        | `search web`                                         |
-| **Description** | Search the web using DashScope MCP WebSearch service |
-| **Usage**       | `bl search web --query <text> [flags]`               |
+| Field              | Value                                                |
+| ------------------ | ---------------------------------------------------- |
+| **Name**           | `search web`                                         |
+| **Description**    | Search the web using DashScope MCP WebSearch service |
+| **Authentication** | API Key                                              |
+| **Usage**          | `bl search web --query <text> [flags]`               |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/skill.md
+++ b/skills/bailian-cli/reference/skill.md
@@ -7,23 +7,24 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command           | Description                                                             |
-| ----------------- | ----------------------------------------------------------------------- |
-| `bl skill add`    | Install skills from the Bailian skill registry into local agents        |
-| `bl skill init`   | Install all bailian-\* skills (one-shot bootstrap for new environments) |
-| `bl skill list`   | List registry skills and diff against local installs                    |
-| `bl skill remove` | Remove locally installed skills (registry is untouched)                 |
-| `bl skill update` | Update installed skills to the latest registry versions                 |
+| Command           | Authentication | Description                                                             |
+| ----------------- | -------------- | ----------------------------------------------------------------------- |
+| `bl skill add`    | No Auth        | Install skills from the Bailian skill registry into local agents        |
+| `bl skill init`   | No Auth        | Install all bailian-\* skills (one-shot bootstrap for new environments) |
+| `bl skill list`   | No Auth        | List registry skills and diff against local installs                    |
+| `bl skill remove` | No Auth        | Remove locally installed skills (registry is untouched)                 |
+| `bl skill update` | No Auth        | Update installed skills to the latest registry versions                 |
 
 ## Command details
 
 ### `bl skill add`
 
-| Field           | Value                                                            |
-| --------------- | ---------------------------------------------------------------- |
-| **Name**        | `skill add`                                                      |
-| **Description** | Install skills from the Bailian skill registry into local agents |
-| **Usage**       | `bl skill add --all \| --name <name,...>`                        |
+| Field              | Value                                                            |
+| ------------------ | ---------------------------------------------------------------- |
+| **Name**           | `skill add`                                                      |
+| **Description**    | Install skills from the Bailian skill registry into local agents |
+| **Authentication** | No Auth                                                          |
+| **Usage**          | `bl skill add --all \| --name <name,...>`                        |
 
 #### Flags
 
@@ -44,11 +45,12 @@ bl skill add --name spark-video,bailian-model-recommend
 
 ### `bl skill init`
 
-| Field           | Value                                                                   |
-| --------------- | ----------------------------------------------------------------------- |
-| **Name**        | `skill init`                                                            |
-| **Description** | Install all bailian-\* skills (one-shot bootstrap for new environments) |
-| **Usage**       | `bl skill init`                                                         |
+| Field              | Value                                                                   |
+| ------------------ | ----------------------------------------------------------------------- |
+| **Name**           | `skill init`                                                            |
+| **Description**    | Install all bailian-\* skills (one-shot bootstrap for new environments) |
+| **Authentication** | No Auth                                                                 |
+| **Usage**          | `bl skill init`                                                         |
 
 #### Flags
 
@@ -67,11 +69,12 @@ bl skill init
 
 ### `bl skill list`
 
-| Field           | Value                                                |
-| --------------- | ---------------------------------------------------- |
-| **Name**        | `skill list`                                         |
-| **Description** | List registry skills and diff against local installs |
-| **Usage**       | `bl skill list`                                      |
+| Field              | Value                                                |
+| ------------------ | ---------------------------------------------------- |
+| **Name**           | `skill list`                                         |
+| **Description**    | List registry skills and diff against local installs |
+| **Authentication** | No Auth                                              |
+| **Usage**          | `bl skill list`                                      |
 
 #### Flags
 
@@ -93,11 +96,12 @@ bl skill list --output json
 
 ### `bl skill remove`
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| **Name**        | `skill remove`                                          |
-| **Description** | Remove locally installed skills (registry is untouched) |
-| **Usage**       | `bl skill remove --name <all\|name,...>`                |
+| Field              | Value                                                   |
+| ------------------ | ------------------------------------------------------- |
+| **Name**           | `skill remove`                                          |
+| **Description**    | Remove locally installed skills (registry is untouched) |
+| **Authentication** | No Auth                                                 |
+| **Usage**          | `bl skill remove --name <all\|name,...>`                |
 
 #### Flags
 
@@ -117,11 +121,12 @@ bl skill remove --name all
 
 ### `bl skill update`
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| **Name**        | `skill update`                                          |
-| **Description** | Update installed skills to the latest registry versions |
-| **Usage**       | `bl skill update [--all] [--name <name,...>]`           |
+| Field              | Value                                                   |
+| ------------------ | ------------------------------------------------------- |
+| **Name**           | `skill update`                                          |
+| **Description**    | Update installed skills to the latest registry versions |
+| **Authentication** | No Auth                                                 |
+| **Usage**          | `bl skill update [--all] [--name <name,...>]`           |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/text.md
+++ b/skills/bailian-cli/reference/text.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command        | Description                                           |
-| -------------- | ----------------------------------------------------- |
-| `bl text chat` | Send a chat completion (OpenAI compatible, DashScope) |
+| Command        | Authentication | Description                                           |
+| -------------- | -------------- | ----------------------------------------------------- |
+| `bl text chat` | API Key        | Send a chat completion (OpenAI compatible, DashScope) |
 
 ## Command details
 
 ### `bl text chat`
 
-| Field           | Value                                                 |
-| --------------- | ----------------------------------------------------- |
-| **Name**        | `text chat`                                           |
-| **Description** | Send a chat completion (OpenAI compatible, DashScope) |
-| **Usage**       | `bl text chat --message <text> [flags]`               |
+| Field              | Value                                                 |
+| ------------------ | ----------------------------------------------------- |
+| **Name**           | `text chat`                                           |
+| **Description**    | Send a chat completion (OpenAI compatible, DashScope) |
+| **Authentication** | API Key                                               |
+| **Usage**          | `bl text chat --message <text> [flags]`               |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/token-plan.md
+++ b/skills/bailian-cli/reference/token-plan.md
@@ -7,22 +7,23 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                      | Description                               |
-| ---------------------------- | ----------------------------------------- |
-| `bl token-plan add-member`   | Add a member to a Token Plan organization |
-| `bl token-plan assign-seats` | Batch assign Token Plan seats to members  |
-| `bl token-plan create-key`   | Create a Token Plan API key for a seat    |
-| `bl token-plan list-seats`   | List Token Plan subscription seat details |
+| Command                      | Authentication | Description                               |
+| ---------------------------- | -------------- | ----------------------------------------- |
+| `bl token-plan add-member`   | AK/SK          | Add a member to a Token Plan organization |
+| `bl token-plan assign-seats` | AK/SK          | Batch assign Token Plan seats to members  |
+| `bl token-plan create-key`   | AK/SK          | Create a Token Plan API key for a seat    |
+| `bl token-plan list-seats`   | AK/SK          | List Token Plan subscription seat details |
 
 ## Command details
 
 ### `bl token-plan add-member`
 
-| Field           | Value                                                                  |
-| --------------- | ---------------------------------------------------------------------- |
-| **Name**        | `token-plan add-member`                                                |
-| **Description** | Add a member to a Token Plan organization                              |
-| **Usage**       | `bl token-plan add-member --account-name <name> --org-id <id> [flags]` |
+| Field              | Value                                                                  |
+| ------------------ | ---------------------------------------------------------------------- |
+| **Name**           | `token-plan add-member`                                                |
+| **Description**    | Add a member to a Token Plan organization                              |
+| **Authentication** | AK/SK                                                                  |
+| **Usage**          | `bl token-plan add-member --account-name <name> --org-id <id> [flags]` |
 
 #### Flags
 
@@ -54,11 +55,12 @@ bl token-plan add-member --account-name member1 --org-id org_123 --spec-type sta
 
 ### `bl token-plan assign-seats`
 
-| Field           | Value                                                                                         |
-| --------------- | --------------------------------------------------------------------------------------------- |
-| **Name**        | `token-plan assign-seats`                                                                     |
-| **Description** | Batch assign Token Plan seats to members                                                      |
-| **Usage**       | `bl token-plan assign-seats --workspace-id <id> --seat-type <type> --account-id <id> [flags]` |
+| Field              | Value                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| **Name**           | `token-plan assign-seats`                                                                     |
+| **Description**    | Batch assign Token Plan seats to members                                                      |
+| **Authentication** | AK/SK                                                                                         |
+| **Usage**          | `bl token-plan assign-seats --workspace-id <id> --seat-type <type> --account-id <id> [flags]` |
 
 #### Flags
 
@@ -86,11 +88,12 @@ bl token-plan assign-seats --workspace-id ws_456 --seat-type pro --account-id ac
 
 ### `bl token-plan create-key`
 
-| Field           | Value                                                                    |
-| --------------- | ------------------------------------------------------------------------ |
-| **Name**        | `token-plan create-key`                                                  |
-| **Description** | Create a Token Plan API key for a seat                                   |
-| **Usage**       | `bl token-plan create-key --account-id <id> --workspace-id <id> [flags]` |
+| Field              | Value                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| **Name**           | `token-plan create-key`                                                  |
+| **Description**    | Create a Token Plan API key for a seat                                   |
+| **Authentication** | AK/SK                                                                    |
+| **Usage**          | `bl token-plan create-key --account-id <id> --workspace-id <id> [flags]` |
 
 #### Flags
 
@@ -117,11 +120,12 @@ bl token-plan create-key --account-id acc_123 --workspace-id ws_456 --descriptio
 
 ### `bl token-plan list-seats`
 
-| Field           | Value                                     |
-| --------------- | ----------------------------------------- |
-| **Name**        | `token-plan list-seats`                   |
-| **Description** | List Token Plan subscription seat details |
-| **Usage**       | `bl token-plan list-seats [flags]`        |
+| Field              | Value                                     |
+| ------------------ | ----------------------------------------- |
+| **Name**           | `token-plan list-seats`                   |
+| **Description**    | List Token Plan subscription seat details |
+| **Authentication** | AK/SK                                     |
+| **Usage**          | `bl token-plan list-seats [flags]`        |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/update.md
+++ b/skills/bailian-cli/reference/update.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command     | Description                                         |
-| ----------- | --------------------------------------------------- |
-| `bl update` | Update the CLI to the latest or a specified version |
+| Command     | Authentication | Description                                         |
+| ----------- | -------------- | --------------------------------------------------- |
+| `bl update` | No Auth        | Update the CLI to the latest or a specified version |
 
 ## Command details
 
 ### `bl update`
 
-| Field           | Value                                               |
-| --------------- | --------------------------------------------------- |
-| **Name**        | `update`                                            |
-| **Description** | Update the CLI to the latest or a specified version |
-| **Usage**       | `bl update [--to <version>]`                        |
+| Field              | Value                                               |
+| ------------------ | --------------------------------------------------- |
+| **Name**           | `update`                                            |
+| **Description**    | Update the CLI to the latest or a specified version |
+| **Authentication** | No Auth                                             |
+| **Usage**          | `bl update [--to <version>]`                        |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/usage.md
+++ b/skills/bailian-cli/reference/usage.md
@@ -7,22 +7,23 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command             | Description                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------ |
-| `bl usage free`     | Query free-tier quota for models (all models if --model is omitted)                        |
-| `bl usage freetier` | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable |
-| `bl usage stats`    | Query model usage statistics                                                               |
-| `bl usage summary`  | Show a unified usage summary: free-tier quota and recent usage overview                    |
+| Command             | Authentication | Description                                                                                |
+| ------------------- | -------------- | ------------------------------------------------------------------------------------------ |
+| `bl usage free`     | Console        | Query free-tier quota for models (all models if --model is omitted)                        |
+| `bl usage freetier` | Console        | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable |
+| `bl usage stats`    | Console        | Query model usage statistics                                                               |
+| `bl usage summary`  | Console        | Show a unified usage summary: free-tier quota and recent usage overview                    |
 
 ## Command details
 
 ### `bl usage free`
 
-| Field           | Value                                                               |
-| --------------- | ------------------------------------------------------------------- |
-| **Name**        | `usage free`                                                        |
-| **Description** | Query free-tier quota for models (all models if --model is omitted) |
-| **Usage**       | `bl usage free [--model <model>[,model2,...]] [flags]`              |
+| Field              | Value                                                               |
+| ------------------ | ------------------------------------------------------------------- |
+| **Name**           | `usage free`                                                        |
+| **Description**    | Query free-tier quota for models (all models if --model is omitted) |
+| **Authentication** | Console                                                             |
+| **Usage**          | `bl usage free [--model <model>[,model2,...]] [flags]`              |
 
 #### Flags
 
@@ -73,11 +74,12 @@ bl usage free --model qwen3-max --console-region cn-beijing
 
 ### `bl usage freetier`
 
-| Field           | Value                                                                                      |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| **Name**        | `usage freetier`                                                                           |
-| **Description** | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable |
-| **Usage**       | `bl usage freetier <--model <model>[,model2,...] \| --all> [--off] [flags]`                |
+| Field              | Value                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| **Name**           | `usage freetier`                                                                           |
+| **Description**    | Enable or disable auto-stop for free-tier models. Enables by default; use --off to disable |
+| **Authentication** | Console                                                                                    |
+| **Usage**          | `bl usage freetier <--model <model>[,model2,...] \| --all> [--off] [flags]`                |
 
 #### Flags
 
@@ -120,11 +122,12 @@ bl usage freetier --off --all
 
 ### `bl usage stats`
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| **Name**        | `usage stats`                                              |
-| **Description** | Query model usage statistics                               |
-| **Usage**       | `bl usage stats [--model <model>] [--days <days>] [flags]` |
+| Field              | Value                                                      |
+| ------------------ | ---------------------------------------------------------- |
+| **Name**           | `usage stats`                                              |
+| **Description**    | Query model usage statistics                               |
+| **Authentication** | Console                                                    |
+| **Usage**          | `bl usage stats [--model <model>] [--days <days>] [flags]` |
 
 #### Flags
 
@@ -170,11 +173,12 @@ bl usage stats --output json
 
 ### `bl usage summary`
 
-| Field           | Value                                                                   |
-| --------------- | ----------------------------------------------------------------------- |
-| **Name**        | `usage summary`                                                         |
-| **Description** | Show a unified usage summary: free-tier quota and recent usage overview |
-| **Usage**       | `bl usage summary [--days <days>] [flags]`                              |
+| Field              | Value                                                                   |
+| ------------------ | ----------------------------------------------------------------------- |
+| **Name**           | `usage summary`                                                         |
+| **Description**    | Show a unified usage summary: free-tier quota and recent usage overview |
+| **Authentication** | Console                                                                 |
+| **Usage**          | `bl usage summary [--days <days>] [flags]`                              |
 
 #### Flags
 

--- a/skills/bailian-cli/reference/workspace.md
+++ b/skills/bailian-cli/reference/workspace.md
@@ -7,20 +7,21 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command             | Description                                                 |
-| ------------------- | ----------------------------------------------------------- |
-| `bl workspace init` | Initialize Bailian workspace and activate postpaid services |
-| `bl workspace list` | List all workspaces                                         |
+| Command             | Authentication | Description                                                 |
+| ------------------- | -------------- | ----------------------------------------------------------- |
+| `bl workspace init` | No Auth        | Initialize Bailian workspace and activate postpaid services |
+| `bl workspace list` | Console        | List all workspaces                                         |
 
 ## Command details
 
 ### `bl workspace init`
 
-| Field           | Value                                                                                            |
-| --------------- | ------------------------------------------------------------------------------------------------ |
-| **Name**        | `workspace init`                                                                                 |
-| **Description** | Initialize Bailian workspace and activate postpaid services                                      |
-| **Usage**       | `bl workspace init --access-key-id <id> --access-key-secret <secret> [--security-token <token>]` |
+| Field              | Value                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------ |
+| **Name**           | `workspace init`                                                                                 |
+| **Description**    | Initialize Bailian workspace and activate postpaid services                                      |
+| **Authentication** | No Auth                                                                                          |
+| **Usage**          | `bl workspace init --access-key-id <id> --access-key-secret <secret> [--security-token <token>]` |
 
 #### Flags
 
@@ -38,11 +39,12 @@ bl workspace init --access-key-id LTAIxxxxx --access-key-secret xxxxx
 
 ### `bl workspace list`
 
-| Field           | Value                       |
-| --------------- | --------------------------- |
-| **Name**        | `workspace list`            |
-| **Description** | List all workspaces         |
-| **Usage**       | `bl workspace list [flags]` |
+| Field              | Value                       |
+| ------------------ | --------------------------- |
+| **Name**           | `workspace list`            |
+| **Description**    | List all workspaces         |
+| **Authentication** | Console                     |
+| **Usage**          | `bl workspace list [flags]` |
 
 #### Flags
 

--- a/skills/bailian-finetune/reference/dataset.md
+++ b/skills/bailian-finetune/reference/dataset.md
@@ -7,23 +7,24 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command               | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `bl dataset delete`   | Delete a dataset file by ID                                        |
-| `bl dataset get`      | Get details of a single dataset file                               |
-| `bl dataset list`     | List uploaded dataset files                                        |
-| `bl dataset upload`   | Upload a dataset file (.jsonl or .zip) to Bailian                  |
-| `bl dataset validate` | Locally validate a dataset file (.jsonl or .zip) without uploading |
+| Command               | Authentication | Description                                                        |
+| --------------------- | -------------- | ------------------------------------------------------------------ |
+| `bl dataset delete`   | API Key        | Delete a dataset file by ID                                        |
+| `bl dataset get`      | API Key        | Get details of a single dataset file                               |
+| `bl dataset list`     | API Key        | List uploaded dataset files                                        |
+| `bl dataset upload`   | API Key        | Upload a dataset file (.jsonl or .zip) to Bailian                  |
+| `bl dataset validate` | No Auth        | Locally validate a dataset file (.jsonl or .zip) without uploading |
 
 ## Command details
 
 ### `bl dataset delete`
 
-| Field           | Value                              |
-| --------------- | ---------------------------------- |
-| **Name**        | `dataset delete`                   |
-| **Description** | Delete a dataset file by ID        |
-| **Usage**       | `bl dataset delete --file-id <id>` |
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| **Name**           | `dataset delete`                   |
+| **Description**    | Delete a dataset file by ID        |
+| **Authentication** | API Key                            |
+| **Usage**          | `bl dataset delete --file-id <id>` |
 
 #### Flags
 
@@ -45,11 +46,12 @@ bl dataset delete --file-id file-id-xxx --dry-run
 
 ### `bl dataset get`
 
-| Field           | Value                                |
-| --------------- | ------------------------------------ |
-| **Name**        | `dataset get`                        |
-| **Description** | Get details of a single dataset file |
-| **Usage**       | `bl dataset get --file-id <id>`      |
+| Field              | Value                                |
+| ------------------ | ------------------------------------ |
+| **Name**           | `dataset get`                        |
+| **Description**    | Get details of a single dataset file |
+| **Authentication** | API Key                              |
+| **Usage**          | `bl dataset get --file-id <id>`      |
 
 #### Flags
 
@@ -71,11 +73,12 @@ bl dataset get --file-id file-xxx --output json
 
 ### `bl dataset list`
 
-| Field           | Value                                                               |
-| --------------- | ------------------------------------------------------------------- |
-| **Name**        | `dataset list`                                                      |
-| **Description** | List uploaded dataset files                                         |
-| **Usage**       | `bl dataset list [--page <n>] [--page-size <n>] [--purpose <name>]` |
+| Field              | Value                                                               |
+| ------------------ | ------------------------------------------------------------------- |
+| **Name**           | `dataset list`                                                      |
+| **Description**    | List uploaded dataset files                                         |
+| **Authentication** | API Key                                                             |
+| **Usage**          | `bl dataset list [--page <n>] [--page-size <n>] [--purpose <name>]` |
 
 #### Flags
 
@@ -107,11 +110,12 @@ bl dataset list --output json
 
 ### `bl dataset upload`
 
-| Field           | Value                                                                                                                            |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `dataset upload`                                                                                                                 |
-| **Description** | Upload a dataset file (.jsonl or .zip) to Bailian                                                                                |
-| **Usage**       | `bl dataset upload --file <path> [--purpose <name>] [--schema <chatml\|dpo\|cpt\|tts\|image>] [--no-validate] [--full-validate]` |
+| Field              | Value                                                                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `dataset upload`                                                                                                                 |
+| **Description**    | Upload a dataset file (.jsonl or .zip) to Bailian                                                                                |
+| **Authentication** | API Key                                                                                                                          |
+| **Usage**          | `bl dataset upload --file <path> [--purpose <name>] [--schema <chatml\|dpo\|cpt\|tts\|image>] [--no-validate] [--full-validate]` |
 
 #### Flags
 
@@ -170,11 +174,12 @@ bl dataset upload --file train.jsonl --no-validate
 
 ### `bl dataset validate`
 
-| Field           | Value                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------- |
-| **Name**        | `dataset validate`                                                                              |
-| **Description** | Locally validate a dataset file (.jsonl or .zip) without uploading                              |
-| **Usage**       | `bl dataset validate --file <path> [--full-validate] [--schema <chatml\|dpo\|cpt\|tts\|image>]` |
+| Field              | Value                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| **Name**           | `dataset validate`                                                                              |
+| **Description**    | Locally validate a dataset file (.jsonl or .zip) without uploading                              |
+| **Authentication** | No Auth                                                                                         |
+| **Usage**          | `bl dataset validate --file <path> [--full-validate] [--schema <chatml\|dpo\|cpt\|tts\|image>]` |
 
 #### Flags
 

--- a/skills/bailian-finetune/reference/deploy.md
+++ b/skills/bailian-finetune/reference/deploy.md
@@ -7,27 +7,28 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                  | Description                                               |
-| ------------------------ | --------------------------------------------------------- |
-| `bl deploy audio create` | Create an audio (TTS) model deployment                    |
-| `bl deploy delete`       | Delete a model deployment (must be STOPPED or FAILED)     |
-| `bl deploy get`          | Get details of a single model deployment                  |
-| `bl deploy image create` | Create an image generation model deployment               |
-| `bl deploy list`         | List model deployments                                    |
-| `bl deploy models`       | List models available for deployment                      |
-| `bl deploy scale`        | Scale a deployment's capacity                             |
-| `bl deploy text create`  | Create a text model deployment                            |
-| `bl deploy update`       | Update a deployment's rate limits (rpm_limit / tpm_limit) |
+| Command                  | Authentication | Description                                               |
+| ------------------------ | -------------- | --------------------------------------------------------- |
+| `bl deploy audio create` | API Key        | Create an audio (TTS) model deployment                    |
+| `bl deploy delete`       | API Key        | Delete a model deployment (must be STOPPED or FAILED)     |
+| `bl deploy get`          | API Key        | Get details of a single model deployment                  |
+| `bl deploy image create` | API Key        | Create an image generation model deployment               |
+| `bl deploy list`         | API Key        | List model deployments                                    |
+| `bl deploy models`       | API Key        | List models available for deployment                      |
+| `bl deploy scale`        | API Key        | Scale a deployment's capacity                             |
+| `bl deploy text create`  | API Key        | Create a text model deployment                            |
+| `bl deploy update`       | API Key        | Update a deployment's rate limits (rpm_limit / tpm_limit) |
 
 ## Command details
 
 ### `bl deploy audio create`
 
-| Field           | Value                                                                                                                                                                                                             |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `deploy audio create`                                                                                                                                                                                             |
-| **Description** | Create an audio (TTS) model deployment                                                                                                                                                                            |
-| **Usage**       | `bl deploy audio create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
+| Field              | Value                                                                                                                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `deploy audio create`                                                                                                                                                                                             |
+| **Description**    | Create an audio (TTS) model deployment                                                                                                                                                                            |
+| **Authentication** | API Key                                                                                                                                                                                                           |
+| **Usage**          | `bl deploy audio create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
 
 #### Flags
 
@@ -83,11 +84,12 @@ bl deploy audio create --model my-cosyvoice-ft --name my-tts --dry-run
 
 ### `bl deploy delete`
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| **Name**        | `deploy delete`                                            |
-| **Description** | Delete a model deployment (must be STOPPED or FAILED)      |
-| **Usage**       | `bl deploy delete --deployed-model <id> [--skip-precheck]` |
+| Field              | Value                                                      |
+| ------------------ | ---------------------------------------------------------- |
+| **Name**           | `deploy delete`                                            |
+| **Description**    | Delete a model deployment (must be STOPPED or FAILED)      |
+| **Authentication** | API Key                                                    |
+| **Usage**          | `bl deploy delete --deployed-model <id> [--skip-precheck]` |
 
 #### Flags
 
@@ -110,11 +112,12 @@ bl deploy delete --deployed-model dep-... --dry-run
 
 ### `bl deploy get`
 
-| Field           | Value                                    |
-| --------------- | ---------------------------------------- |
-| **Name**        | `deploy get`                             |
-| **Description** | Get details of a single model deployment |
-| **Usage**       | `bl deploy get --deployed-model <id>`    |
+| Field              | Value                                    |
+| ------------------ | ---------------------------------------- |
+| **Name**           | `deploy get`                             |
+| **Description**    | Get details of a single model deployment |
+| **Authentication** | API Key                                  |
+| **Usage**          | `bl deploy get --deployed-model <id>`    |
 
 #### Flags
 
@@ -136,11 +139,12 @@ bl deploy get --deployed-model qwen-plus-2025-12-01-b6d61c71 --output json
 
 ### `bl deploy image create`
 
-| Field           | Value                                                                                                                                                                                                             |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `deploy image create`                                                                                                                                                                                             |
-| **Description** | Create an image generation model deployment                                                                                                                                                                       |
-| **Usage**       | `bl deploy image create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
+| Field              | Value                                                                                                                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `deploy image create`                                                                                                                                                                                             |
+| **Description**    | Create an image generation model deployment                                                                                                                                                                       |
+| **Authentication** | API Key                                                                                                                                                                                                           |
+| **Usage**          | `bl deploy image create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
 
 #### Flags
 
@@ -196,11 +200,12 @@ bl deploy image create --model my-wan-ft --name my-wan --dry-run
 
 ### `bl deploy list`
 
-| Field           | Value                                                          |
-| --------------- | -------------------------------------------------------------- |
-| **Name**        | `deploy list`                                                  |
-| **Description** | List model deployments                                         |
-| **Usage**       | `bl deploy list [--page <n>] [--page-size <n>] [--status <s>]` |
+| Field              | Value                                                          |
+| ------------------ | -------------------------------------------------------------- |
+| **Name**           | `deploy list`                                                  |
+| **Description**    | List model deployments                                         |
+| **Authentication** | API Key                                                        |
+| **Usage**          | `bl deploy list [--page <n>] [--page-size <n>] [--status <s>]` |
 
 #### Flags
 
@@ -228,11 +233,12 @@ bl deploy list --page-size 20 --output json
 
 ### `bl deploy models`
 
-| Field           | Value                                                                                                 |
-| --------------- | ----------------------------------------------------------------------------------------------------- |
-| **Name**        | `deploy models`                                                                                       |
-| **Description** | List models available for deployment                                                                  |
-| **Usage**       | `bl deploy models [--page <n>] [--page-size <n>] [--catalog-version <v>] [--source <custom\|public>]` |
+| Field              | Value                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Name**           | `deploy models`                                                                                       |
+| **Description**    | List models available for deployment                                                                  |
+| **Authentication** | API Key                                                                                               |
+| **Usage**          | `bl deploy models [--page <n>] [--page-size <n>] [--catalog-version <v>] [--source <custom\|public>]` |
 
 #### Flags
 
@@ -265,11 +271,12 @@ bl deploy models --catalog-version v1.0 --output json
 
 ### `bl deploy scale`
 
-| Field           | Value                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| **Name**        | `deploy scale`                                                                              |
-| **Description** | Scale a deployment's capacity                                                               |
-| **Usage**       | `bl deploy scale --deployed-model <id> --capacity <n> [--input-tpm <n>] [--output-tpm <n>]` |
+| Field              | Value                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **Name**           | `deploy scale`                                                                              |
+| **Description**    | Scale a deployment's capacity                                                               |
+| **Authentication** | API Key                                                                                     |
+| **Usage**          | `bl deploy scale --deployed-model <id> --capacity <n> [--input-tpm <n>] [--output-tpm <n>]` |
 
 #### Flags
 
@@ -294,11 +301,12 @@ bl deploy scale --deployed-model dep-... --capacity 2
 
 ### `bl deploy text create`
 
-| Field           | Value                                                                                                                                                                                                            |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `deploy text create`                                                                                                                                                                                             |
-| **Description** | Create a text model deployment                                                                                                                                                                                   |
-| **Usage**       | `bl deploy text create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
+| Field              | Value                                                                                                                                                                                                            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `deploy text create`                                                                                                                                                                                             |
+| **Description**    | Create a text model deployment                                                                                                                                                                                   |
+| **Authentication** | API Key                                                                                                                                                                                                          |
+| **Usage**          | `bl deploy text create --model <model_name> --name <display_name> [--plan <plan>] [--deploy-spec <id>] [--capacity <n>] [--billing-method <m>] [--input-tpm <n>] [--output-tpm <n>] [--thinking-output-tpm <n>]` |
 
 #### Flags
 
@@ -358,11 +366,12 @@ bl deploy text create --model qwen3-8b --name my-qwen3 --plan mu --deploy-spec M
 
 ### `bl deploy update`
 
-| Field           | Value                                                                        |
-| --------------- | ---------------------------------------------------------------------------- |
-| **Name**        | `deploy update`                                                              |
-| **Description** | Update a deployment's rate limits (rpm_limit / tpm_limit)                    |
-| **Usage**       | `bl deploy update --deployed-model <id> [--rpm-limit <n>] [--tpm-limit <n>]` |
+| Field              | Value                                                                        |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Name**           | `deploy update`                                                              |
+| **Description**    | Update a deployment's rate limits (rpm_limit / tpm_limit)                    |
+| **Authentication** | API Key                                                                      |
+| **Usage**          | `bl deploy update --deployed-model <id> [--rpm-limit <n>] [--tpm-limit <n>]` |
 
 #### Flags
 

--- a/skills/bailian-finetune/reference/finetune.md
+++ b/skills/bailian-finetune/reference/finetune.md
@@ -7,30 +7,31 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                    | Description                                                                                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `bl finetune audio create` | Create an audio TTS model fine-tune job (sft-lora)                                                                              |
-| `bl finetune cancel`       | Cancel a running fine-tune job                                                                                                  |
-| `bl finetune capability`   | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) |
-| `bl finetune checkpoints`  | List checkpoints produced by a fine-tune job                                                                                    |
-| `bl finetune delete`       | Delete a fine-tune job record                                                                                                   |
-| `bl finetune export`       | Publish a checkpoint as a deployable model                                                                                      |
-| `bl finetune get`          | Get details of a single fine-tune job                                                                                           |
-| `bl finetune image create` | Create an image generation model fine-tune job (sft-lora)                                                                       |
-| `bl finetune list`         | List fine-tune jobs                                                                                                             |
-| `bl finetune logs`         | Fetch training logs for a fine-tune job                                                                                         |
-| `bl finetune text create`  | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                   |
-| `bl finetune watch`        | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal.                      |
+| Command                    | Authentication | Description                                                                                                                     |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `bl finetune audio create` | API Key        | Create an audio TTS model fine-tune job (sft-lora)                                                                              |
+| `bl finetune cancel`       | API Key        | Cancel a running fine-tune job                                                                                                  |
+| `bl finetune capability`   | No Auth        | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) |
+| `bl finetune checkpoints`  | API Key        | List checkpoints produced by a fine-tune job                                                                                    |
+| `bl finetune delete`       | API Key        | Delete a fine-tune job record                                                                                                   |
+| `bl finetune export`       | API Key        | Publish a checkpoint as a deployable model                                                                                      |
+| `bl finetune get`          | API Key        | Get details of a single fine-tune job                                                                                           |
+| `bl finetune image create` | API Key        | Create an image generation model fine-tune job (sft-lora)                                                                       |
+| `bl finetune list`         | API Key        | List fine-tune jobs                                                                                                             |
+| `bl finetune logs`         | API Key        | Fetch training logs for a fine-tune job                                                                                         |
+| `bl finetune text create`  | API Key        | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                   |
+| `bl finetune watch`        | API Key        | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal.                      |
 
 ## Command details
 
 ### `bl finetune audio create`
 
-| Field           | Value                                                                                                                               |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `finetune audio create`                                                                                                             |
-| **Description** | Create an audio TTS model fine-tune job (sft-lora)                                                                                  |
-| **Usage**       | `bl finetune audio create --model <model> --datasets <id\|path> [--validations <id\|path>] [--model-name <name>] [--suffix <text>]` |
+| Field              | Value                                                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `finetune audio create`                                                                                                             |
+| **Description**    | Create an audio TTS model fine-tune job (sft-lora)                                                                                  |
+| **Authentication** | API Key                                                                                                                             |
+| **Usage**          | `bl finetune audio create --model <model> --datasets <id\|path> [--validations <id\|path>] [--model-name <name>] [--suffix <text>]` |
 
 #### Flags
 
@@ -79,11 +80,12 @@ bl finetune audio create --model cosyvoice-v3-flash --datasets ./audio.zip --dry
 
 ### `bl finetune cancel`
 
-| Field           | Value                              |
-| --------------- | ---------------------------------- |
-| **Name**        | `finetune cancel`                  |
-| **Description** | Cancel a running fine-tune job     |
-| **Usage**       | `bl finetune cancel --job-id <id>` |
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| **Name**           | `finetune cancel`                  |
+| **Description**    | Cancel a running fine-tune job     |
+| **Authentication** | API Key                            |
+| **Usage**          | `bl finetune cancel --job-id <id>` |
 
 #### Flags
 
@@ -110,11 +112,12 @@ bl finetune cancel --job-id ft-xxx --dry-run
 
 ### `bl finetune capability`
 
-| Field           | Value                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `finetune capability`                                                                                                           |
-| **Description** | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) |
-| **Usage**       | `bl finetune capability --model <m> \| --training-type <t>`                                                                     |
+| Field              | Value                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `finetune capability`                                                                                                           |
+| **Description**    | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) |
+| **Authentication** | No Auth                                                                                                                         |
+| **Usage**          | `bl finetune capability --model <m> \| --training-type <t>`                                                                     |
 
 #### Flags
 
@@ -150,11 +153,12 @@ bl finetune capability --training-type sft --quiet
 
 ### `bl finetune checkpoints`
 
-| Field           | Value                                        |
-| --------------- | -------------------------------------------- |
-| **Name**        | `finetune checkpoints`                       |
-| **Description** | List checkpoints produced by a fine-tune job |
-| **Usage**       | `bl finetune checkpoints --job-id <id>`      |
+| Field              | Value                                        |
+| ------------------ | -------------------------------------------- |
+| **Name**           | `finetune checkpoints`                       |
+| **Description**    | List checkpoints produced by a fine-tune job |
+| **Authentication** | API Key                                      |
+| **Usage**          | `bl finetune checkpoints --job-id <id>`      |
 
 #### Flags
 
@@ -181,11 +185,12 @@ bl finetune checkpoints --job-id ft-xxx --output json
 
 ### `bl finetune delete`
 
-| Field           | Value                              |
-| --------------- | ---------------------------------- |
-| **Name**        | `finetune delete`                  |
-| **Description** | Delete a fine-tune job record      |
-| **Usage**       | `bl finetune delete --job-id <id>` |
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| **Name**           | `finetune delete`                  |
+| **Description**    | Delete a fine-tune job record      |
+| **Authentication** | API Key                            |
+| **Usage**          | `bl finetune delete --job-id <id>` |
 
 #### Flags
 
@@ -212,11 +217,12 @@ bl finetune delete --job-id ft-xxx --dry-run
 
 ### `bl finetune export`
 
-| Field           | Value                                                                      |
-| --------------- | -------------------------------------------------------------------------- |
-| **Name**        | `finetune export`                                                          |
-| **Description** | Publish a checkpoint as a deployable model                                 |
-| **Usage**       | `bl finetune export --job-id <id> --checkpoint <name> --model-name <name>` |
+| Field              | Value                                                                      |
+| ------------------ | -------------------------------------------------------------------------- |
+| **Name**           | `finetune export`                                                          |
+| **Description**    | Publish a checkpoint as a deployable model                                 |
+| **Authentication** | API Key                                                                    |
+| **Usage**          | `bl finetune export --job-id <id> --checkpoint <name> --model-name <name>` |
 
 #### Flags
 
@@ -242,11 +248,12 @@ bl finetune export --job-id ft-xxx --checkpoint ckpt-3 --model-name my-qwen-sft
 
 ### `bl finetune get`
 
-| Field           | Value                                 |
-| --------------- | ------------------------------------- |
-| **Name**        | `finetune get`                        |
-| **Description** | Get details of a single fine-tune job |
-| **Usage**       | `bl finetune get --job-id <id>`       |
+| Field              | Value                                 |
+| ------------------ | ------------------------------------- |
+| **Name**           | `finetune get`                        |
+| **Description**    | Get details of a single fine-tune job |
+| **Authentication** | API Key                               |
+| **Usage**          | `bl finetune get --job-id <id>`       |
 
 #### Flags
 
@@ -268,11 +275,12 @@ bl finetune get --job-id ft-xxx --output json
 
 ### `bl finetune image create`
 
-| Field           | Value                                                                                                                                                                                      |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Name**        | `finetune image create`                                                                                                                                                                    |
-| **Description** | Create an image generation model fine-tune job (sft-lora)                                                                                                                                  |
-| **Usage**       | `bl finetune image create --model <model> --datasets <id\|path> [--validations <id\|path>] [--model-name <name>] [--suffix <text>] [--generation-type <t2i\|i2i>] [--learning-rate <str>]` |
+| Field              | Value                                                                                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Name**           | `finetune image create`                                                                                                                                                                    |
+| **Description**    | Create an image generation model fine-tune job (sft-lora)                                                                                                                                  |
+| **Authentication** | API Key                                                                                                                                                                                    |
+| **Usage**          | `bl finetune image create --model <model> --datasets <id\|path> [--validations <id\|path>] [--model-name <name>] [--suffix <text>] [--generation-type <t2i\|i2i>] [--learning-rate <str>]` |
 
 #### Flags
 
@@ -329,11 +337,12 @@ bl finetune image create --model wan2.7-image-pro --datasets ./images.zip --dry-
 
 ### `bl finetune list`
 
-| Field           | Value                                                            |
-| --------------- | ---------------------------------------------------------------- |
-| **Name**        | `finetune list`                                                  |
-| **Description** | List fine-tune jobs                                              |
-| **Usage**       | `bl finetune list [--page <n>] [--page-size <n>] [--status <s>]` |
+| Field              | Value                                                            |
+| ------------------ | ---------------------------------------------------------------- |
+| **Name**           | `finetune list`                                                  |
+| **Description**    | List fine-tune jobs                                              |
+| **Authentication** | API Key                                                          |
+| **Usage**          | `bl finetune list [--page <n>] [--page-size <n>] [--status <s>]` |
 
 #### Flags
 
@@ -361,11 +370,12 @@ bl finetune list --page-size 20 --output json
 
 ### `bl finetune logs`
 
-| Field           | Value                                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------------- |
-| **Name**        | `finetune logs`                                                                                   |
-| **Description** | Fetch training logs for a fine-tune job                                                           |
-| **Usage**       | `bl finetune logs --job-id <id> [--page <n>] [--page-size <n>] [--search <keyword>] [--tail <n>]` |
+| Field              | Value                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| **Name**           | `finetune logs`                                                                                   |
+| **Description**    | Fetch training logs for a fine-tune job                                                           |
+| **Authentication** | API Key                                                                                           |
+| **Usage**          | `bl finetune logs --job-id <id> [--page <n>] [--page-size <n>] [--search <keyword>] [--tail <n>]` |
 
 #### Flags
 
@@ -407,11 +417,12 @@ bl finetune logs --job-id ft-xxx --search checkpoint --tail 5
 
 ### `bl finetune text create`
 
-| Field           | Value                                                                                                                                                                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**        | `finetune text create`                                                                                                                                                                                                                                                          |
-| **Description** | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                                                                                                                                                                   |
-| **Usage**       | `bl finetune text create --model <model> --datasets <id\|path,...> [--validations <id\|path,...>] [--model-name <name>] [--suffix <text>] [--n-epochs <n>] [--batch-size <n>] [--learning-rate <str>] [--max-length <n>] [--training-type <sft\|sft-lora\|dpo\|dpo-lora\|cpt>]` |
+| Field              | Value                                                                                                                                                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**           | `finetune text create`                                                                                                                                                                                                                                                          |
+| **Description**    | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                                                                                                                                                                   |
+| **Authentication** | API Key                                                                                                                                                                                                                                                                         |
+| **Usage**          | `bl finetune text create --model <model> --datasets <id\|path,...> [--validations <id\|path,...>] [--model-name <name>] [--suffix <text>] [--n-epochs <n>] [--batch-size <n>] [--learning-rate <str>] [--max-length <n>] [--training-type <sft\|sft-lora\|dpo\|dpo-lora\|cpt>]` |
 
 #### Flags
 
@@ -486,11 +497,12 @@ bl finetune text create --model qwen3-8b --datasets file-xxx --dry-run
 
 ### `bl finetune watch`
 
-| Field           | Value                                                                                                      |
-| --------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Name**        | `finetune watch`                                                                                           |
-| **Description** | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal. |
-| **Usage**       | `bl finetune watch --job-id <id> [--follow] [--interval <sec>] [--poll-timeout <sec>]`                     |
+| Field              | Value                                                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Name**           | `finetune watch`                                                                                           |
+| **Description**    | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal. |
+| **Authentication** | API Key                                                                                                    |
+| **Usage**          | `bl finetune watch --job-id <id> [--follow] [--interval <sec>] [--poll-timeout <sec>]`                     |
 
 #### Flags
 

--- a/skills/bailian-finetune/reference/index.md
+++ b/skills/bailian-finetune/reference/index.md
@@ -9,34 +9,34 @@ Use this index for the skill-scoped quick index and global flags.
 
 ## Quick index
 
-| Command                    | Description                                                                                                                     | Detail                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `bl dataset delete`        | Delete a dataset file by ID                                                                                                     | [dataset.md](dataset.md)   |
-| `bl dataset get`           | Get details of a single dataset file                                                                                            | [dataset.md](dataset.md)   |
-| `bl dataset list`          | List uploaded dataset files                                                                                                     | [dataset.md](dataset.md)   |
-| `bl dataset upload`        | Upload a dataset file (.jsonl or .zip) to Bailian                                                                               | [dataset.md](dataset.md)   |
-| `bl dataset validate`      | Locally validate a dataset file (.jsonl or .zip) without uploading                                                              | [dataset.md](dataset.md)   |
-| `bl deploy audio create`   | Create an audio (TTS) model deployment                                                                                          | [deploy.md](deploy.md)     |
-| `bl deploy delete`         | Delete a model deployment (must be STOPPED or FAILED)                                                                           | [deploy.md](deploy.md)     |
-| `bl deploy get`            | Get details of a single model deployment                                                                                        | [deploy.md](deploy.md)     |
-| `bl deploy image create`   | Create an image generation model deployment                                                                                     | [deploy.md](deploy.md)     |
-| `bl deploy list`           | List model deployments                                                                                                          | [deploy.md](deploy.md)     |
-| `bl deploy models`         | List models available for deployment                                                                                            | [deploy.md](deploy.md)     |
-| `bl deploy scale`          | Scale a deployment's capacity                                                                                                   | [deploy.md](deploy.md)     |
-| `bl deploy text create`    | Create a text model deployment                                                                                                  | [deploy.md](deploy.md)     |
-| `bl deploy update`         | Update a deployment's rate limits (rpm_limit / tpm_limit)                                                                       | [deploy.md](deploy.md)     |
-| `bl finetune audio create` | Create an audio TTS model fine-tune job (sft-lora)                                                                              | [finetune.md](finetune.md) |
-| `bl finetune cancel`       | Cancel a running fine-tune job                                                                                                  | [finetune.md](finetune.md) |
-| `bl finetune capability`   | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) | [finetune.md](finetune.md) |
-| `bl finetune checkpoints`  | List checkpoints produced by a fine-tune job                                                                                    | [finetune.md](finetune.md) |
-| `bl finetune delete`       | Delete a fine-tune job record                                                                                                   | [finetune.md](finetune.md) |
-| `bl finetune export`       | Publish a checkpoint as a deployable model                                                                                      | [finetune.md](finetune.md) |
-| `bl finetune get`          | Get details of a single fine-tune job                                                                                           | [finetune.md](finetune.md) |
-| `bl finetune image create` | Create an image generation model fine-tune job (sft-lora)                                                                       | [finetune.md](finetune.md) |
-| `bl finetune list`         | List fine-tune jobs                                                                                                             | [finetune.md](finetune.md) |
-| `bl finetune logs`         | Fetch training logs for a fine-tune job                                                                                         | [finetune.md](finetune.md) |
-| `bl finetune text create`  | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                   | [finetune.md](finetune.md) |
-| `bl finetune watch`        | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal.                      | [finetune.md](finetune.md) |
+| Command                    | Authentication | Description                                                                                                                     | Detail                     |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `bl dataset delete`        | API Key        | Delete a dataset file by ID                                                                                                     | [dataset.md](dataset.md)   |
+| `bl dataset get`           | API Key        | Get details of a single dataset file                                                                                            | [dataset.md](dataset.md)   |
+| `bl dataset list`          | API Key        | List uploaded dataset files                                                                                                     | [dataset.md](dataset.md)   |
+| `bl dataset upload`        | API Key        | Upload a dataset file (.jsonl or .zip) to Bailian                                                                               | [dataset.md](dataset.md)   |
+| `bl dataset validate`      | No Auth        | Locally validate a dataset file (.jsonl or .zip) without uploading                                                              | [dataset.md](dataset.md)   |
+| `bl deploy audio create`   | API Key        | Create an audio (TTS) model deployment                                                                                          | [deploy.md](deploy.md)     |
+| `bl deploy delete`         | API Key        | Delete a model deployment (must be STOPPED or FAILED)                                                                           | [deploy.md](deploy.md)     |
+| `bl deploy get`            | API Key        | Get details of a single model deployment                                                                                        | [deploy.md](deploy.md)     |
+| `bl deploy image create`   | API Key        | Create an image generation model deployment                                                                                     | [deploy.md](deploy.md)     |
+| `bl deploy list`           | API Key        | List model deployments                                                                                                          | [deploy.md](deploy.md)     |
+| `bl deploy models`         | API Key        | List models available for deployment                                                                                            | [deploy.md](deploy.md)     |
+| `bl deploy scale`          | API Key        | Scale a deployment's capacity                                                                                                   | [deploy.md](deploy.md)     |
+| `bl deploy text create`    | API Key        | Create a text model deployment                                                                                                  | [deploy.md](deploy.md)     |
+| `bl deploy update`         | API Key        | Update a deployment's rate limits (rpm_limit / tpm_limit)                                                                       | [deploy.md](deploy.md)     |
+| `bl finetune audio create` | API Key        | Create an audio TTS model fine-tune job (sft-lora)                                                                              | [finetune.md](finetune.md) |
+| `bl finetune cancel`       | API Key        | Cancel a running fine-tune job                                                                                                  | [finetune.md](finetune.md) |
+| `bl finetune capability`   | No Auth        | Query fine-tune training capability — by model (which training types it supports) or by training type (which models support it) | [finetune.md](finetune.md) |
+| `bl finetune checkpoints`  | API Key        | List checkpoints produced by a fine-tune job                                                                                    | [finetune.md](finetune.md) |
+| `bl finetune delete`       | API Key        | Delete a fine-tune job record                                                                                                   | [finetune.md](finetune.md) |
+| `bl finetune export`       | API Key        | Publish a checkpoint as a deployable model                                                                                      | [finetune.md](finetune.md) |
+| `bl finetune get`          | API Key        | Get details of a single fine-tune job                                                                                           | [finetune.md](finetune.md) |
+| `bl finetune image create` | API Key        | Create an image generation model fine-tune job (sft-lora)                                                                       | [finetune.md](finetune.md) |
+| `bl finetune list`         | API Key        | List fine-tune jobs                                                                                                             | [finetune.md](finetune.md) |
+| `bl finetune logs`         | API Key        | Fetch training logs for a fine-tune job                                                                                         | [finetune.md](finetune.md) |
+| `bl finetune text create`  | API Key        | Create a text model fine-tune job (sft \| sft-lora \| dpo \| dpo-lora \| cpt)                                                   | [finetune.md](finetune.md) |
+| `bl finetune watch`        | API Key        | Probe a fine-tune job's status (default: single non-blocking fetch). Pass --follow to poll until terminal.                      | [finetune.md](finetune.md) |
 
 ## By group
 

--- a/skills/bailian-gen/reference/image.md
+++ b/skills/bailian-gen/reference/image.md
@@ -7,20 +7,21 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command             | Description                                                          |
-| ------------------- | -------------------------------------------------------------------- |
-| `bl image edit`     | Edit an existing image with text instructions (Qwen-Image / Wan 2.7) |
-| `bl image generate` | Generate images (Qwen-Image / wan2.x)                                |
+| Command             | Authentication | Description                                                          |
+| ------------------- | -------------- | -------------------------------------------------------------------- |
+| `bl image edit`     | API Key        | Edit an existing image with text instructions (Qwen-Image / Wan 2.7) |
+| `bl image generate` | API Key        | Generate images (Qwen-Image / wan2.x)                                |
 
 ## Command details
 
 ### `bl image edit`
 
-| Field           | Value                                                                |
-| --------------- | -------------------------------------------------------------------- |
-| **Name**        | `image edit`                                                         |
-| **Description** | Edit an existing image with text instructions (Qwen-Image / Wan 2.7) |
-| **Usage**       | `bl image edit --image <url> --prompt <text> [flags]`                |
+| Field              | Value                                                                |
+| ------------------ | -------------------------------------------------------------------- |
+| **Name**           | `image edit`                                                         |
+| **Description**    | Edit an existing image with text instructions (Qwen-Image / Wan 2.7) |
+| **Authentication** | API Key                                                              |
+| **Usage**          | `bl image edit --image <url> --prompt <text> [flags]`                |
 
 #### Flags
 
@@ -80,11 +81,12 @@ bl image edit --image ./photo.png --prompt "Replace the background with a beach"
 
 ### `bl image generate`
 
-| Field           | Value                                       |
-| --------------- | ------------------------------------------- |
-| **Name**        | `image generate`                            |
-| **Description** | Generate images (Qwen-Image / wan2.x)       |
-| **Usage**       | `bl image generate --prompt <text> [flags]` |
+| Field              | Value                                       |
+| ------------------ | ------------------------------------------- |
+| **Name**           | `image generate`                            |
+| **Description**    | Generate images (Qwen-Image / wan2.x)       |
+| **Authentication** | API Key                                     |
+| **Usage**          | `bl image generate --prompt <text> [flags]` |
 
 #### Flags
 

--- a/skills/bailian-gen/reference/index.md
+++ b/skills/bailian-gen/reference/index.md
@@ -9,19 +9,19 @@ Use this index for the skill-scoped quick index and global flags.
 
 ## Quick index
 
-| Command                | Description                                                                                           | Detail                 |
-| ---------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------- |
-| `bl image edit`        | Edit an existing image with text instructions (Qwen-Image / Wan 2.7)                                  | [image.md](image.md)   |
-| `bl image generate`    | Generate images (Qwen-Image / wan2.x)                                                                 | [image.md](image.md)   |
-| `bl omni`              | Multimodal chat with text + audio output (Qwen-Omni)                                                  | [omni.md](omni.md)     |
-| `bl speech recognize`  | Recognize speech from audio files (FunAudio-ASR)                                                      | [speech.md](speech.md) |
-| `bl speech synthesize` | Synthesize speech from text (CosyVoice TTS)                                                           | [speech.md](speech.md) |
-| `bl video download`    | Download a completed video by task ID                                                                 | [video.md](video.md)   |
-| `bl video edit`        | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)                | [video.md](video.md)   |
-| `bl video generate`    | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v)            | [video.md](video.md)   |
-| `bl video ref`         | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice | [video.md](video.md)   |
-| `bl video task get`    | Query async task status                                                                               | [video.md](video.md)   |
-| `bl vision describe`   | Describe an image or video using Qwen-VL                                                              | [vision.md](vision.md) |
+| Command                | Authentication | Description                                                                                           | Detail                 |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------- | ---------------------- |
+| `bl image edit`        | API Key        | Edit an existing image with text instructions (Qwen-Image / Wan 2.7)                                  | [image.md](image.md)   |
+| `bl image generate`    | API Key        | Generate images (Qwen-Image / wan2.x)                                                                 | [image.md](image.md)   |
+| `bl omni`              | API Key        | Multimodal chat with text + audio output (Qwen-Omni)                                                  | [omni.md](omni.md)     |
+| `bl speech recognize`  | API Key        | Recognize speech from audio files (FunAudio-ASR)                                                      | [speech.md](speech.md) |
+| `bl speech synthesize` | API Key        | Synthesize speech from text (CosyVoice TTS)                                                           | [speech.md](speech.md) |
+| `bl video download`    | API Key        | Download a completed video by task ID                                                                 | [video.md](video.md)   |
+| `bl video edit`        | API Key        | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)                | [video.md](video.md)   |
+| `bl video generate`    | API Key        | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v)            | [video.md](video.md)   |
+| `bl video ref`         | API Key        | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice | [video.md](video.md)   |
+| `bl video task get`    | API Key        | Query async task status                                                                               | [video.md](video.md)   |
+| `bl vision describe`   | API Key        | Describe an image or video using Qwen-VL                                                              | [vision.md](vision.md) |
 
 ## By group
 

--- a/skills/bailian-gen/reference/omni.md
+++ b/skills/bailian-gen/reference/omni.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command   | Description                                          |
-| --------- | ---------------------------------------------------- |
-| `bl omni` | Multimodal chat with text + audio output (Qwen-Omni) |
+| Command   | Authentication | Description                                          |
+| --------- | -------------- | ---------------------------------------------------- |
+| `bl omni` | API Key        | Multimodal chat with text + audio output (Qwen-Omni) |
 
 ## Command details
 
 ### `bl omni`
 
-| Field           | Value                                                |
-| --------------- | ---------------------------------------------------- |
-| **Name**        | `omni`                                               |
-| **Description** | Multimodal chat with text + audio output (Qwen-Omni) |
-| **Usage**       | `bl omni --message <text> [flags]`                   |
+| Field              | Value                                                |
+| ------------------ | ---------------------------------------------------- |
+| **Name**           | `omni`                                               |
+| **Description**    | Multimodal chat with text + audio output (Qwen-Omni) |
+| **Authentication** | API Key                                              |
+| **Usage**          | `bl omni --message <text> [flags]`                   |
 
 #### Flags
 

--- a/skills/bailian-gen/reference/speech.md
+++ b/skills/bailian-gen/reference/speech.md
@@ -7,20 +7,21 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                | Description                                      |
-| ---------------------- | ------------------------------------------------ |
-| `bl speech recognize`  | Recognize speech from audio files (FunAudio-ASR) |
-| `bl speech synthesize` | Synthesize speech from text (CosyVoice TTS)      |
+| Command                | Authentication | Description                                      |
+| ---------------------- | -------------- | ------------------------------------------------ |
+| `bl speech recognize`  | API Key        | Recognize speech from audio files (FunAudio-ASR) |
+| `bl speech synthesize` | API Key        | Synthesize speech from text (CosyVoice TTS)      |
 
 ## Command details
 
 ### `bl speech recognize`
 
-| Field           | Value                                            |
-| --------------- | ------------------------------------------------ |
-| **Name**        | `speech recognize`                               |
-| **Description** | Recognize speech from audio files (FunAudio-ASR) |
-| **Usage**       | `bl speech recognize --url <audio-url> [flags]`  |
+| Field              | Value                                            |
+| ------------------ | ------------------------------------------------ |
+| **Name**           | `speech recognize`                               |
+| **Description**    | Recognize speech from audio files (FunAudio-ASR) |
+| **Authentication** | API Key                                          |
+| **Usage**          | `bl speech recognize --url <audio-url> [flags]`  |
 
 #### Flags
 
@@ -71,11 +72,12 @@ bl speech recognize --url https://example.com/audio.mp3 --async --quiet
 
 ### `bl speech synthesize`
 
-| Field           | Value                                        |
-| --------------- | -------------------------------------------- |
-| **Name**        | `speech synthesize`                          |
-| **Description** | Synthesize speech from text (CosyVoice TTS)  |
-| **Usage**       | `bl speech synthesize --text <text> [flags]` |
+| Field              | Value                                        |
+| ------------------ | -------------------------------------------- |
+| **Name**           | `speech synthesize`                          |
+| **Description**    | Synthesize speech from text (CosyVoice TTS)  |
+| **Authentication** | API Key                                      |
+| **Usage**          | `bl speech synthesize --text <text> [flags]` |
 
 #### Flags
 

--- a/skills/bailian-gen/reference/video.md
+++ b/skills/bailian-gen/reference/video.md
@@ -7,23 +7,24 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command             | Description                                                                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------- |
-| `bl video download` | Download a completed video by task ID                                                                 |
-| `bl video edit`     | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)                |
-| `bl video generate` | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v)            |
-| `bl video ref`      | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice |
-| `bl video task get` | Query async task status                                                                               |
+| Command             | Authentication | Description                                                                                           |
+| ------------------- | -------------- | ----------------------------------------------------------------------------------------------------- |
+| `bl video download` | API Key        | Download a completed video by task ID                                                                 |
+| `bl video edit`     | API Key        | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.)                |
+| `bl video generate` | API Key        | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v)            |
+| `bl video ref`      | API Key        | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice |
+| `bl video task get` | API Key        | Query async task status                                                                               |
 
 ## Command details
 
 ### `bl video download`
 
-| Field           | Value                                           |
-| --------------- | ----------------------------------------------- |
-| **Name**        | `video download`                                |
-| **Description** | Download a completed video by task ID           |
-| **Usage**       | `bl video download --task-id <id> --out <path>` |
+| Field              | Value                                           |
+| ------------------ | ----------------------------------------------- |
+| **Name**           | `video download`                                |
+| **Description**    | Download a completed video by task ID           |
+| **Authentication** | API Key                                         |
+| **Usage**          | `bl video download --task-id <id> --out <path>` |
 
 #### Flags
 
@@ -46,11 +47,12 @@ bl video download --task-id 3b256896-xxxx --out video.mp4 --quiet
 
 ### `bl video edit`
 
-| Field           | Value                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------- |
-| **Name**        | `video edit`                                                                           |
-| **Description** | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.) |
-| **Usage**       | `bl video edit --video <url> --prompt <text> [flags]`                                  |
+| Field              | Value                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| **Name**           | `video edit`                                                                           |
+| **Description**    | Edit a video with happyhorse-1.0-video-edit (style transfer, object replacement, etc.) |
+| **Authentication** | API Key                                                                                |
+| **Usage**          | `bl video edit --video <url> --prompt <text> [flags]`                                  |
 
 #### Flags
 
@@ -95,11 +97,12 @@ bl video edit --video https://example.com/input.mp4 --prompt "Put clothes on the
 
 ### `bl video generate`
 
-| Field           | Value                                                                                      |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| **Name**        | `video generate`                                                                           |
-| **Description** | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v) |
-| **Usage**       | `bl video generate --prompt <text> [--image <url>] [flags]`                                |
+| Field              | Value                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| **Name**           | `video generate`                                                                           |
+| **Description**    | Generate a video from text or image (happyhorse-1.1-t2v / happyhorse-1.1-i2v / wan2.6-t2v) |
+| **Authentication** | API Key                                                                                    |
+| **Usage**          | `bl video generate --prompt <text> [--image <url>] [flags]`                                |
 
 #### Flags
 
@@ -146,11 +149,12 @@ bl video generate --prompt "A cat playing with a ball" --watermark false
 
 ### `bl video ref`
 
-| Field           | Value                                                                                                 |
-| --------------- | ----------------------------------------------------------------------------------------------------- |
-| **Name**        | `video ref`                                                                                           |
-| **Description** | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice |
-| **Usage**       | `bl video ref --prompt <text> --image <url>... [--ref-video <url>...] [flags]`                        |
+| Field              | Value                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Name**           | `video ref`                                                                                           |
+| **Description**    | Reference-to-video generation (happyhorse-1.1-r2v / wan2.6-r2v): multi-subject, multi-shot with voice |
+| **Authentication** | API Key                                                                                               |
+| **Usage**          | `bl video ref --prompt <text> --image <url>... [--ref-video <url>...] [flags]`                        |
 
 #### Flags
 
@@ -199,11 +203,12 @@ bl video ref --prompt "Image 1 drinks water" --image person.jpg --watermark fals
 
 ### `bl video task get`
 
-| Field           | Value                              |
-| --------------- | ---------------------------------- |
-| **Name**        | `video task get`                   |
-| **Description** | Query async task status            |
-| **Usage**       | `bl video task get --task-id <id>` |
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| **Name**           | `video task get`                   |
+| **Description**    | Query async task status            |
+| **Authentication** | API Key                            |
+| **Usage**          | `bl video task get --task-id <id>` |
 
 #### Flags
 

--- a/skills/bailian-gen/reference/vision.md
+++ b/skills/bailian-gen/reference/vision.md
@@ -7,19 +7,20 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command              | Description                              |
-| -------------------- | ---------------------------------------- |
-| `bl vision describe` | Describe an image or video using Qwen-VL |
+| Command              | Authentication | Description                              |
+| -------------------- | -------------- | ---------------------------------------- |
+| `bl vision describe` | API Key        | Describe an image or video using Qwen-VL |
 
 ## Command details
 
 ### `bl vision describe`
 
-| Field           | Value                                                                        |
-| --------------- | ---------------------------------------------------------------------------- |
-| **Name**        | `vision describe`                                                            |
-| **Description** | Describe an image or video using Qwen-VL                                     |
-| **Usage**       | `bl vision describe --image <path-or-url> [--video <url>] [--prompt <text>]` |
+| Field              | Value                                                                        |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Name**           | `vision describe`                                                            |
+| **Description**    | Describe an image or video using Qwen-VL                                     |
+| **Authentication** | API Key                                                                      |
+| **Usage**          | `bl vision describe --image <path-or-url> [--video <url>] [--prompt <text>]` |
 
 #### Flags
 

--- a/skills/bailian-managed-agent/reference/index.md
+++ b/skills/bailian-managed-agent/reference/index.md
@@ -9,25 +9,25 @@ Use this index for the skill-scoped quick index and global flags.
 
 ## Quick index
 
-| Command                           | Description                                                   | Detail                               |
-| --------------------------------- | ------------------------------------------------------------- | ------------------------------------ |
-| `bl managed-agent apply`          | Apply planned changes to create/update/delete agent resources | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent destroy`        | Destroy all managed agent resources tracked in state          | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent init`           | Create a new agents.yaml template                             | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent plan`           | Show what changes would be applied to agent infrastructure    | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session create` | Create a new session for an agent                             | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session delete` | Delete a session                                              | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session events` | List event history for a session                              | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session get`    | Get details of a session                                      | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session list`   | List sessions from the provider                               | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session run`    | Create a session, send a message, and stream the response     | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent session send`   | Send a message to an existing session and stream the response | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent skill-list`     | List skills from the provider's skill catalog                 | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent state import`   | Import an existing remote resource into agents state          | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent state list`     | List resources tracked in agents state                        | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent state rm`       | Remove a resource from state without destroying it remotely   | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent state show`     | Show details of a resource in agents state                    | [managed-agent.md](managed-agent.md) |
-| `bl managed-agent validate`       | Validate an agents.yaml configuration (offline)               | [managed-agent.md](managed-agent.md) |
+| Command                           | Authentication | Description                                                   | Detail                               |
+| --------------------------------- | -------------- | ------------------------------------------------------------- | ------------------------------------ |
+| `bl managed-agent apply`          | API Key        | Apply planned changes to create/update/delete agent resources | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent destroy`        | API Key        | Destroy all managed agent resources tracked in state          | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent init`           | No Auth        | Create a new agents.yaml template                             | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent plan`           | API Key        | Show what changes would be applied to agent infrastructure    | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session create` | API Key        | Create a new session for an agent                             | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session delete` | API Key        | Delete a session                                              | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session events` | API Key        | List event history for a session                              | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session get`    | API Key        | Get details of a session                                      | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session list`   | API Key        | List sessions from the provider                               | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session run`    | API Key        | Create a session, send a message, and stream the response     | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent session send`   | API Key        | Send a message to an existing session and stream the response | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent skill-list`     | API Key        | List skills from the provider's skill catalog                 | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent state import`   | API Key        | Import an existing remote resource into agents state          | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent state list`     | No Auth        | List resources tracked in agents state                        | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent state rm`       | No Auth        | Remove a resource from state without destroying it remotely   | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent state show`     | No Auth        | Show details of a resource in agents state                    | [managed-agent.md](managed-agent.md) |
+| `bl managed-agent validate`       | No Auth        | Validate an agents.yaml configuration (offline)               | [managed-agent.md](managed-agent.md) |
 
 ## By group
 

--- a/skills/bailian-managed-agent/reference/managed-agent.md
+++ b/skills/bailian-managed-agent/reference/managed-agent.md
@@ -7,35 +7,36 @@ Index: [index.md](index.md)
 
 ## Commands in this group
 
-| Command                           | Description                                                   |
-| --------------------------------- | ------------------------------------------------------------- |
-| `bl managed-agent apply`          | Apply planned changes to create/update/delete agent resources |
-| `bl managed-agent destroy`        | Destroy all managed agent resources tracked in state          |
-| `bl managed-agent init`           | Create a new agents.yaml template                             |
-| `bl managed-agent plan`           | Show what changes would be applied to agent infrastructure    |
-| `bl managed-agent session create` | Create a new session for an agent                             |
-| `bl managed-agent session delete` | Delete a session                                              |
-| `bl managed-agent session events` | List event history for a session                              |
-| `bl managed-agent session get`    | Get details of a session                                      |
-| `bl managed-agent session list`   | List sessions from the provider                               |
-| `bl managed-agent session run`    | Create a session, send a message, and stream the response     |
-| `bl managed-agent session send`   | Send a message to an existing session and stream the response |
-| `bl managed-agent skill-list`     | List skills from the provider's skill catalog                 |
-| `bl managed-agent state import`   | Import an existing remote resource into agents state          |
-| `bl managed-agent state list`     | List resources tracked in agents state                        |
-| `bl managed-agent state rm`       | Remove a resource from state without destroying it remotely   |
-| `bl managed-agent state show`     | Show details of a resource in agents state                    |
-| `bl managed-agent validate`       | Validate an agents.yaml configuration (offline)               |
+| Command                           | Authentication | Description                                                   |
+| --------------------------------- | -------------- | ------------------------------------------------------------- |
+| `bl managed-agent apply`          | API Key        | Apply planned changes to create/update/delete agent resources |
+| `bl managed-agent destroy`        | API Key        | Destroy all managed agent resources tracked in state          |
+| `bl managed-agent init`           | No Auth        | Create a new agents.yaml template                             |
+| `bl managed-agent plan`           | API Key        | Show what changes would be applied to agent infrastructure    |
+| `bl managed-agent session create` | API Key        | Create a new session for an agent                             |
+| `bl managed-agent session delete` | API Key        | Delete a session                                              |
+| `bl managed-agent session events` | API Key        | List event history for a session                              |
+| `bl managed-agent session get`    | API Key        | Get details of a session                                      |
+| `bl managed-agent session list`   | API Key        | List sessions from the provider                               |
+| `bl managed-agent session run`    | API Key        | Create a session, send a message, and stream the response     |
+| `bl managed-agent session send`   | API Key        | Send a message to an existing session and stream the response |
+| `bl managed-agent skill-list`     | API Key        | List skills from the provider's skill catalog                 |
+| `bl managed-agent state import`   | API Key        | Import an existing remote resource into agents state          |
+| `bl managed-agent state list`     | No Auth        | List resources tracked in agents state                        |
+| `bl managed-agent state rm`       | No Auth        | Remove a resource from state without destroying it remotely   |
+| `bl managed-agent state show`     | No Auth        | Show details of a resource in agents state                    |
+| `bl managed-agent validate`       | No Auth        | Validate an agents.yaml configuration (offline)               |
 
 ## Command details
 
 ### `bl managed-agent apply`
 
-| Field           | Value                                                                                    |
-| --------------- | ---------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent apply`                                                                    |
-| **Description** | Apply planned changes to create/update/delete agent resources                            |
-| **Usage**       | `bl managed-agent apply [--file <path>] [--provider <name>] [--yes] [--concurrency <n>]` |
+| Field              | Value                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent apply`                                                                    |
+| **Description**    | Apply planned changes to create/update/delete agent resources                            |
+| **Authentication** | API Key                                                                                  |
+| **Usage**          | `bl managed-agent apply [--file <path>] [--provider <name>] [--yes] [--concurrency <n>]` |
 
 #### Flags
 
@@ -67,11 +68,12 @@ bl managed-agent apply --provider bailian --yes
 
 ### `bl managed-agent destroy`
 
-| Field           | Value                                                          |
-| --------------- | -------------------------------------------------------------- |
-| **Name**        | `managed-agent destroy`                                        |
-| **Description** | Destroy all managed agent resources tracked in state           |
-| **Usage**       | `bl managed-agent destroy [--file <path>] [--yes] [--cascade]` |
+| Field              | Value                                                          |
+| ------------------ | -------------------------------------------------------------- |
+| **Name**           | `managed-agent destroy`                                        |
+| **Description**    | Destroy all managed agent resources tracked in state           |
+| **Authentication** | API Key                                                        |
+| **Usage**          | `bl managed-agent destroy [--file <path>] [--yes] [--cascade]` |
 
 #### Flags
 
@@ -101,11 +103,12 @@ bl managed-agent destroy --yes --cascade
 
 ### `bl managed-agent init`
 
-| Field           | Value                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent init`                                                                        |
-| **Description** | Create a new agents.yaml template                                                           |
-| **Usage**       | `bl managed-agent init [--provider <name>] [--agent-name <name>] [--file <path>] [--force]` |
+| Field              | Value                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent init`                                                                        |
+| **Description**    | Create a new agents.yaml template                                                           |
+| **Authentication** | No Auth                                                                                     |
+| **Usage**          | `bl managed-agent init [--provider <name>] [--agent-name <name>] [--file <path>] [--force]` |
 
 #### Flags
 
@@ -132,11 +135,12 @@ bl managed-agent init --provider all
 
 ### `bl managed-agent plan`
 
-| Field           | Value                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent plan`                                                                        |
-| **Description** | Show what changes would be applied to agent infrastructure                                  |
-| **Usage**       | `bl managed-agent plan [--file <path>] [--provider <name>] [--no-refresh] [--refresh-only]` |
+| Field              | Value                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent plan`                                                                        |
+| **Description**    | Show what changes would be applied to agent infrastructure                                  |
+| **Authentication** | API Key                                                                                     |
+| **Usage**          | `bl managed-agent plan [--file <path>] [--provider <name>] [--no-refresh] [--refresh-only]` |
 
 #### Flags
 
@@ -172,11 +176,12 @@ bl managed-agent plan --no-refresh
 
 ### `bl managed-agent session create`
 
-| Field           | Value                                                                                                       |
-| --------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent session create`                                                                              |
-| **Description** | Create a new session for an agent                                                                           |
-| **Usage**       | `bl managed-agent session create [--agent <name>] [--environment <name>] [--title <title>] [--file <path>]` |
+| Field              | Value                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent session create`                                                                              |
+| **Description**    | Create a new session for an agent                                                                           |
+| **Authentication** | API Key                                                                                                     |
+| **Usage**          | `bl managed-agent session create [--agent <name>] [--environment <name>] [--title <title>] [--file <path>]` |
 
 #### Flags
 
@@ -214,11 +219,12 @@ bl managed-agent session create --agent assistant --title 'debug run'
 
 ### `bl managed-agent session delete`
 
-| Field           | Value                                                                                   |
-| --------------- | --------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent session delete`                                                          |
-| **Description** | Delete a session                                                                        |
-| **Usage**       | `bl managed-agent session delete --session-id <id> [--provider <name>] [--file <path>]` |
+| Field              | Value                                                                                   |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent session delete`                                                          |
+| **Description**    | Delete a session                                                                        |
+| **Authentication** | API Key                                                                                 |
+| **Usage**          | `bl managed-agent session delete --session-id <id> [--provider <name>] [--file <path>]` |
 
 #### Flags
 
@@ -244,11 +250,12 @@ bl managed-agent session delete --session-id sess_abc123
 
 ### `bl managed-agent session events`
 
-| Field           | Value                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent session events`                                                            |
-| **Description** | List event history for a session                                                          |
-| **Usage**       | `bl managed-agent session events --session-id <id> [--limit <n>] [--all] [--file <path>]` |
+| Field              | Value                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent session events`                                                            |
+| **Description**    | List event history for a session                                                          |
+| **Authentication** | API Key                                                                                   |
+| **Usage**          | `bl managed-agent session events --session-id <id> [--limit <n>] [--all] [--file <path>]` |
 
 #### Flags
 
@@ -280,11 +287,12 @@ bl managed-agent session events --session-id sess_abc123 --all
 
 ### `bl managed-agent session get`
 
-| Field           | Value                                                                                |
-| --------------- | ------------------------------------------------------------------------------------ |
-| **Name**        | `managed-agent session get`                                                          |
-| **Description** | Get details of a session                                                             |
-| **Usage**       | `bl managed-agent session get --session-id <id> [--provider <name>] [--file <path>]` |
+| Field              | Value                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| **Name**           | `managed-agent session get`                                                          |
+| **Description**    | Get details of a session                                                             |
+| **Authentication** | API Key                                                                              |
+| **Usage**          | `bl managed-agent session get --session-id <id> [--provider <name>] [--file <path>]` |
 
 #### Flags
 
@@ -310,11 +318,12 @@ bl managed-agent session get --session-id sess_abc123
 
 ### `bl managed-agent session list`
 
-| Field           | Value                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent session list`                                                                 |
-| **Description** | List sessions from the provider                                                              |
-| **Usage**       | `bl managed-agent session list [--agent <name>] [--all] [--provider <name>] [--file <path>]` |
+| Field              | Value                                                                                        |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent session list`                                                                 |
+| **Description**    | List sessions from the provider                                                              |
+| **Authentication** | API Key                                                                                      |
+| **Usage**          | `bl managed-agent session list [--agent <name>] [--all] [--provider <name>] [--file <path>]` |
 
 #### Flags
 
@@ -349,11 +358,12 @@ bl managed-agent session list --all
 
 ### `bl managed-agent session run`
 
-| Field           | Value                                                                                         |
-| --------------- | --------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent session run`                                                                   |
-| **Description** | Create a session, send a message, and stream the response                                     |
-| **Usage**       | `bl managed-agent session run --prompt <text> [--agent <name>] [--no-stream] [--file <path>]` |
+| Field              | Value                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent session run`                                                                   |
+| **Description**    | Create a session, send a message, and stream the response                                     |
+| **Authentication** | API Key                                                                                       |
+| **Usage**          | `bl managed-agent session run --prompt <text> [--agent <name>] [--no-stream] [--file <path>]` |
 
 #### Flags
 
@@ -390,11 +400,12 @@ bl managed-agent session run --agent assistant --prompt "summarize this repo"
 
 ### `bl managed-agent session send`
 
-| Field           | Value                                                                                            |
-| --------------- | ------------------------------------------------------------------------------------------------ |
-| **Name**        | `managed-agent session send`                                                                     |
-| **Description** | Send a message to an existing session and stream the response                                    |
-| **Usage**       | `bl managed-agent session send --session-id <id> --message <text> [--no-stream] [--file <path>]` |
+| Field              | Value                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------ |
+| **Name**           | `managed-agent session send`                                                                     |
+| **Description**    | Send a message to an existing session and stream the response                                    |
+| **Authentication** | API Key                                                                                          |
+| **Usage**          | `bl managed-agent session send --session-id <id> --message <text> [--no-stream] [--file <path>]` |
 
 #### Flags
 
@@ -422,11 +433,12 @@ bl managed-agent session send --session-id sess_abc123 --message "continue"
 
 ### `bl managed-agent skill-list`
 
-| Field           | Value                                                                                              |
-| --------------- | -------------------------------------------------------------------------------------------------- |
-| **Name**        | `managed-agent skill-list`                                                                         |
-| **Description** | List skills from the provider's skill catalog                                                      |
-| **Usage**       | `bl managed-agent skill-list [--source custom\|official\|all] [--provider <name>] [--file <path>]` |
+| Field              | Value                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------- |
+| **Name**           | `managed-agent skill-list`                                                                         |
+| **Description**    | List skills from the provider's skill catalog                                                      |
+| **Authentication** | API Key                                                                                            |
+| **Usage**          | `bl managed-agent skill-list [--source custom\|official\|all] [--provider <name>] [--file <path>]` |
 
 #### Flags
 
@@ -467,11 +479,12 @@ bl managed-agent skill-list --source custom --provider bailian
 
 ### `bl managed-agent state import`
 
-| Field           | Value                                                                                                                    |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **Name**        | `managed-agent state import`                                                                                             |
-| **Description** | Import an existing remote resource into agents state                                                                     |
-| **Usage**       | `bl managed-agent state import --address <provider.type.name> --remote-id <id> [--resource-version <n>] [--file <path>]` |
+| Field              | Value                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| **Name**           | `managed-agent state import`                                                                                             |
+| **Description**    | Import an existing remote resource into agents state                                                                     |
+| **Authentication** | API Key                                                                                                                  |
+| **Usage**          | `bl managed-agent state import --address <provider.type.name> --remote-id <id> [--resource-version <n>] [--file <path>]` |
 
 #### Flags
 
@@ -498,11 +511,12 @@ bl managed-agent state import --address bailian.agent.assistant --remote-id agen
 
 ### `bl managed-agent state list`
 
-| Field           | Value                                         |
-| --------------- | --------------------------------------------- |
-| **Name**        | `managed-agent state list`                    |
-| **Description** | List resources tracked in agents state        |
-| **Usage**       | `bl managed-agent state list [--file <path>]` |
+| Field              | Value                                         |
+| ------------------ | --------------------------------------------- |
+| **Name**           | `managed-agent state list`                    |
+| **Description**    | List resources tracked in agents state        |
+| **Authentication** | No Auth                                       |
+| **Usage**          | `bl managed-agent state list [--file <path>]` |
 
 #### Flags
 
@@ -526,11 +540,12 @@ bl managed-agent state list --file agents.yaml
 
 ### `bl managed-agent state rm`
 
-| Field           | Value                                                                      |
-| --------------- | -------------------------------------------------------------------------- |
-| **Name**        | `managed-agent state rm`                                                   |
-| **Description** | Remove a resource from state without destroying it remotely                |
-| **Usage**       | `bl managed-agent state rm --address <provider.type.name> [--file <path>]` |
+| Field              | Value                                                                      |
+| ------------------ | -------------------------------------------------------------------------- |
+| **Name**           | `managed-agent state rm`                                                   |
+| **Description**    | Remove a resource from state without destroying it remotely                |
+| **Authentication** | No Auth                                                                    |
+| **Usage**          | `bl managed-agent state rm --address <provider.type.name> [--file <path>]` |
 
 #### Flags
 
@@ -551,11 +566,12 @@ bl managed-agent state rm --address bailian.agent.assistant
 
 ### `bl managed-agent state show`
 
-| Field           | Value                                                                        |
-| --------------- | ---------------------------------------------------------------------------- |
-| **Name**        | `managed-agent state show`                                                   |
-| **Description** | Show details of a resource in agents state                                   |
-| **Usage**       | `bl managed-agent state show --address <provider.type.name> [--file <path>]` |
+| Field              | Value                                                                        |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Name**           | `managed-agent state show`                                                   |
+| **Description**    | Show details of a resource in agents state                                   |
+| **Authentication** | No Auth                                                                      |
+| **Usage**          | `bl managed-agent state show --address <provider.type.name> [--file <path>]` |
 
 #### Flags
 
@@ -576,11 +592,12 @@ bl managed-agent state show --address bailian.agent.assistant
 
 ### `bl managed-agent validate`
 
-| Field           | Value                                           |
-| --------------- | ----------------------------------------------- |
-| **Name**        | `managed-agent validate`                        |
-| **Description** | Validate an agents.yaml configuration (offline) |
-| **Usage**       | `bl managed-agent validate [--file <path>]`     |
+| Field              | Value                                           |
+| ------------------ | ----------------------------------------------- |
+| **Name**           | `managed-agent validate`                        |
+| **Description**    | Validate an agents.yaml configuration (offline) |
+| **Authentication** | No Auth                                         |
+| **Usage**          | `bl managed-agent validate [--file <path>]`     |
 
 #### Flags
 

--- a/skills/bailian-protocol/assets/setup.md
+++ b/skills/bailian-protocol/assets/setup.md
@@ -29,12 +29,14 @@ Verify: `bl --version` (prints `bl X.Y.Z`).
 
 ## Authentication
 
+For the exact command-to-auth mapping, read the owning skill's `reference/index.md` or run `bl <command> --help`.
+
 | Auth               | How                                                                                              | Used by                                       |
 | ------------------ | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
 | API key            | `export DASHSCOPE_API_KEY=sk-...` or `bl auth login --api-key sk-...`                            | Most DashScope API commands                   |
 | Token Plan API key | `bl auth login --config token-plan --api-key sk-sp-...`                                          | Token Plan text, image, and video consumption |
 | Console            | `bl auth login --console --console-site domestic` or `... international`                         | `app list`, `usage free`, `console call`      |
-| OpenAPI AK         | `bl auth login --open-api --access-key-id <id> --access-key-secret <secret>` or Alibaba env vars | Token Plan management commands (`token-plan`) |
+| OpenAPI AK/SK      | `bl auth login --open-api --access-key-id <id> --access-key-secret <secret>` or Alibaba env vars | Token Plan management commands (`token-plan`) |
 
 ```bash
 bl auth status            # check current auth
@@ -45,6 +47,8 @@ bl auth logout --open-api # clear OpenAPI AK/SK only
 
 - Get a DashScope API key: https://bailian.console.aliyun.com/cn-beijing/?tab=app#/api-key
 - Get a Token Plan API key: https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/overview
+- Get an Alibaba Cloud AccessKey for OpenAPI AK/SK: https://ram.console.aliyun.com/manage/ak
+- Console login: China site https://bailian.console.aliyun.com or international site https://modelstudio.console.alibabacloud.com
 
 ### Token Plan model consumption
 

--- a/tools/generate-reference.ts
+++ b/tools/generate-reference.ts
@@ -23,6 +23,7 @@ import {
   OPENAPI_AUTH_FLAGS,
   credentialFlagDefs,
   type AnyCommand,
+  type AuthRequirement,
   type FlagDef,
   type FlagsDef,
 } from "../packages/core/src/index.ts";
@@ -57,6 +58,13 @@ const GROUP_OWNER_SKILL: Readonly<Record<string, string>> = {
 const GENERATED_BANNER =
   "> Auto-generated from `packages/cli/src/commands.ts`. Do not edit by hand.\n" +
   "> Regenerate: `pnpm --filter bailian-cli run generate:reference`.";
+
+const AUTH_LABELS = {
+  apiKey: "API Key",
+  console: "Console",
+  openapi: "AK/SK",
+  none: "No Auth",
+} satisfies Record<AuthRequirement, string>;
 
 function escCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ").trim();
@@ -119,6 +127,7 @@ function commandSection(path: string, cmd: AnyCommand): string {
   lines.push(`| Field | Value |`, `| --- | --- |`);
   lines.push(`| **Name** | \`${escCell(path)}\` |`);
   lines.push(`| **Description** | ${escCell(cmd.description)} |`);
+  lines.push(`| **Authentication** | ${AUTH_LABELS[cmd.auth]} |`);
   // Commands store argument-only usage; the `bl <path>` prefix is added here.
   const usage = `bl ${path}${cmd.usageArgs ? ` ${cmd.usageArgs}` : ""}`;
   lines.push(`| **Usage** | \`${escCell(usage)}\` |`);
@@ -167,12 +176,12 @@ function buildGroupFile(group: string, groupEntries: [string, AnyCommand][]): st
     "",
     "## Commands in this group",
     "",
-    "| Command | Description |",
-    "| --- | --- |",
+    "| Command | Authentication | Description |",
+    "| --- | --- | --- |",
   ];
 
   for (const [path, cmd] of groupEntries) {
-    lines.push(`| \`bl ${path}\` | ${escCell(cmd.description)} |`);
+    lines.push(`| \`bl ${path}\` | ${AUTH_LABELS[cmd.auth]} | ${escCell(cmd.description)} |`);
   }
 
   lines.push("", "## Command details", "");
@@ -199,13 +208,15 @@ function buildIndex(
     "",
     "## Quick index",
     "",
-    "| Command | Description | Detail |",
-    "| --- | --- | --- |",
+    "| Command | Authentication | Description | Detail |",
+    "| --- | --- | --- | --- |",
   ];
 
   for (const [path, cmd] of entries) {
     const group = topLevel(path);
-    lines.push(`| \`bl ${path}\` | ${escCell(cmd.description)} | [${group}.md](${group}.md) |`);
+    lines.push(
+      `| \`bl ${path}\` | ${AUTH_LABELS[cmd.auth]} | ${escCell(cmd.description)} | [${group}.md](${group}.md) |`,
+    );
   }
 
   lines.push("", "## By group", "", "| Group | Commands | Reference |", "| --- | --- | --- |");
@@ -220,7 +231,6 @@ function buildIndex(
   }
 
   lines.push(
-    "",
     "## Global flags",
     "",
     "Available on every command (in addition to command-specific flags):",


### PR DESCRIPTION
## Summary

- show each command's authentication domain in root and group help
- add a concise `Authentication: <label>` line to leaf command help
- generate the same authentication metadata in Bailian Skill references
- point the shared setup guide to credential configuration and acquisition pages

The labels are derived directly from each command's `auth` metadata: `API Key`, `Console`, `AK/SK`, and `No Auth`.

Addresses #147.

## Validation

- `vp check` — 0 errors; 3 pre-existing unrelated warnings
- `vp test packages/runtime/tests packages/cli/tests/e2e/registry.smoke.e2e.test.ts` — 220 passed
- `pnpm run sync:skill-assets` — generated 110 command references; repeated generation was idempotent
- full `vp test` — 861 passed, 11 skipped, 19 live-service E2E failures caused by current credentials/service availability (for example `InvalidApiKey`, unavailable models, site mismatch, and missing test app); no failures were in the changed help/reference paths

## Notes

`No Auth` means the runtime does not require a pre-existing stored CLI credential. Setup commands such as `auth login` or `workspace init` may still accept credentials through their own flags.