### PR TITLE
chore(release): prepare 1.15.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "CLI for Aliyun Model Studio (DashScope) AI Platform.",
   "keywords": [
     "agent",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-commands",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Command library for bailian-cli products (knowledge, memory, media, …). See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-core",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Core SDK for bailian-cli. See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/packages/kscli/package.json
+++ b/packages/kscli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-studio-cli",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Lightweight RAG CLI for Aliyun Model Studio — focused on knowledge-base retrieval.",
   "keywords": [
     "alibaba-cloud",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-runtime",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Runtime framework for bailian-cli (createCli, registry, args, output, pipeline). See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/skills/bailian-cli/SKILL.md
+++ b/skills/bailian-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-cli
 metadata:
-  version: "1.14.3"
+  version: "1.15.0"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-finetune/SKILL.md
+++ b/skills/bailian-finetune/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-finetune
 metadata:
-  version: "1.14.3"
+  version: "1.15.0"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-gen/SKILL.md
+++ b/skills/bailian-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-gen
 metadata:
-  version: "1.14.3"
+  version: "1.15.0"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-managed-agent/SKILL.md
+++ b/skills/bailian-managed-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-managed-agent
 metadata:
-  version: "1.14.3"
+  version: "1.15.0"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-protocol/SKILL.md
+++ b/skills/bailian-protocol/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-protocol
 metadata:
-  version: "1.14.3"
+  version: "1.15.0"
   requires:
     bins: ["bl"]
 description: >-


### PR DESCRIPTION
## Summary

- bump `bailian-cli-core`, `bailian-cli-runtime`, `bailian-cli-commands`, `bailian-cli`, and `knowledge-studio-cli` from 1.14.3 to 1.15.0
- synchronize all first-party Bailian Skill `metadata.version` fields to 1.15.0
- complete the version metadata required for the existing 1.15.0 changelog entry and stable Publish workflow

## Validation

- `pnpm run sync:skill-assets`
- `vp check` (0 errors; 5 pre-existing warnings outside this diff)
- `CI=true node tools/release/publish-channel.mjs --channel test --knowledge --dry-run`
  - generated references matched
  - all five packages built and packed
  - publint passed for all five packages
  - gitleaks found no leaks
- `git diff --check`
