### PR TITLE
chore(release): prepare 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 [中文版](CHANGELOG.zh.md) · [README](README.md) · [Contributing](CONTRIBUTING.md)
 
-## [1.17.0] - 2026-08-17
+## [1.17.0] - 2026-08-18
 
 ### Added
 
 - **Native Bailian Managed Agent Deployments** — `deployments` declared in `agents.yaml` now materialize as native AgentStudio resources, with server-side cron schedules, local file resource uploads, archival through `destroy`, and migration of legacy emulated state on the next `apply`.
+- **Bilingual CLI experience** — Set `language` to `en-US` or `zh-CN` through `bl config set` or Config UI to switch CLI Help, Quick Start, command examples, and Config UI between English and Chinese. The selected language follows the active config.
+
+### Fixed
+
+- **Free Tier Auto-Stop controls** — `bl usage freetier --off` can now disable Auto-Stop even when free quota remains; status rendering reflects the actual switch state, and filtered model queries avoid server-side batch-limit failures.
 
 ## [1.16.0] - 2026-08-17
 

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -6,11 +6,16 @@
 
 [English](CHANGELOG.md) · [README](README.zh.md) · [参与贡献](CONTRIBUTING.zh.md)
 
-## [1.17.0] - 2026-08-17
+## [1.17.0] - 2026-08-18
 
 ### 新增
 
 - **百炼原生 Managed Agent Deployment** —— `agents.yaml` 中声明的 `deployments` 现在会创建原生 AgentStudio 资源，支持服务端 Cron 调度、本地文件资源上传、通过 `destroy` 归档，以及在下次 `apply` 时迁移旧版模拟 Deployment state。
+- **CLI 中英文体验** —— 可通过 `bl config set` 或 Config UI 将 `language` 设置为 `en-US` 或 `zh-CN`，在英文和中文的 CLI Help、Quick Start、命令示例及 Config UI 之间切换；所选语言跟随当前激活的配置。
+
+### 修复
+
+- **Free Tier Auto-Stop 控制** —— `bl usage freetier --off` 现在可在免费额度尚有剩余时关闭 Auto-Stop；状态展示会反映实际开关状态，并仅查询筛选后的模型，避免触发服务端批量查询上限。
 
 ## [1.16.0] - 2026-08-17
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ bl config list
 
 # Switch config profile
 bl config use --name token-plan
+
+# Switch the CLI interface to Chinese
+bl config set --key language --value zh-CN
 ```
 
 Config file location: `~/.bailian/config.json`

--- a/README.zh.md
+++ b/README.zh.md
@@ -165,6 +165,9 @@ bl config list
 
 # 切换配置档
 bl config use --name token-plan
+
+# 将 CLI 界面切换为中文
+bl config set --key language --value zh-CN
 ```
 
 配置文件位置：`~/.bailian/config.json`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -166,6 +166,9 @@ bl config list
 
 # Switch config profile
 bl config use --name token-plan
+
+# Switch the CLI interface to Chinese
+bl config set --key language --value zh-CN
 ```
 
 Config file location: `~/.bailian/config.json`

--- a/packages/cli/README.zh.md
+++ b/packages/cli/README.zh.md
@@ -165,6 +165,9 @@ bl config list
 
 # 切换配置档
 bl config use --name token-plan
+
+# 将 CLI 界面切换为中文
+bl config set --key language --value zh-CN
 ```
 
 配置文件位置：`~/.bailian/config.json`

--- a/skills/bailian-cli/SKILL.md
+++ b/skills/bailian-cli/SKILL.md
@@ -75,6 +75,7 @@ Use this table only after the decision table in [`bailian-protocol`](../bailian-
 | Bailian Coding Plan quota usage                  | `bl usage coding-plan`                        | Console auth; class 2 — ask which product first if unnamed                       |
 | Console API (advanced)                           | `bl console call`                             | Console auth                                                                     |
 | Bailian workspace listing                        | `bl workspace list`                           | Console auth                                                                     |
+| Switch CLI Help / Quick Start language           | `bl config set --key language --value zh-CN`  | Use `en-US` to switch back; follows the active config profile                    |
 | Image / video / speech / omni / vision           | → skill `bailian-gen`                         | Fallback: `bl image\|video\|speech\|omni\|vision --help`                         |
 | Dataset / fine-tune / deploy                     | → skill `bailian-finetune`                    | Fallback: `bl dataset\|finetune\|deploy --help`                                  |
 | agents.yaml IaC / managed-agent sessions         | → skill `bailian-managed-agent`               | Fallback: `bl managed-agent --help`; `apply`/`destroy` need `--yes` after `plan` |


### PR DESCRIPTION
## Summary

- finalize the bilingual `1.17.0` changelog for native Managed Agent Deployments, CLI language switching, and Free Tier Auto-Stop fixes
- document the `language` configuration in the English and Chinese root/npm READMEs
- expose the language-switch command in the `bailian-cli` hub Skill while keeping generated command details in `reference/config.md`
- retain the already-synchronized `1.17.0` versions across all five packages and Bailian Skills

## Verification

- `vp check` — 0 errors (5 existing warnings)
- `vp test packages/runtime/tests/i18n.test.ts packages/commands/tests/config-ui.test.ts` — 17 passed
- `pnpm run sync:skill-assets` — generated references and Skill versions are synchronized
- `CI=true node tools/release/publish-channel.mjs --channel test --knowledge --dry-run` — five-package build, pack, publint, and gitleaks checks passed
- root/package English and Chinese README copies match; `git diff --check` passed

## Test note

A full `vp test` run was attempted. It entered live service-backed E2E suites and produced unrelated environment/service failures across knowledge, media generation, quota, and other integrations, then remained running and was stopped. The directly affected localization tests and the complete release dry-run passed.