### PR TITLE
Clarify install guide skill fallback and post-install tips

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,11 +132,11 @@ bl config set --key language --value en-US
 
 ## 6. 常见问题
 
-| 现象                     | 可能原因                     | 建议动作                                                                             |
-| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------ |
-| `bl: command not found`  | bin 不在 PATH                | 检查 `~/.local/bin` 或 `npm prefix -g`                                               |
-| curl 安装 404            | GitHub Release 资产未上传    | 改用 `npm install -g bailian-cli`                                                    |
-| Windows `bl update` 失败 | 旧布局 / 文件锁 / 网络       | 重跑 `irm .../install.ps1 \| iex` 迁移布局后重试                                     |
-| `plugin` 需要 npm        | 二进制安装无本机 npm         | 安装 Node，或改用 npm 版 CLI                                                         |
-| 安装报错 engines         | Node 版本过低（仅 npm 路径） | 升级到 ≥ 18.17.0                                                                     |
+| 现象                     | 可能原因                     | 建议动作                                                                                       |
+| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| `bl: command not found`  | bin 不在 PATH                | 检查 `~/.local/bin` 或 `npm prefix -g`                                                         |
+| curl 安装 404            | GitHub Release 资产未上传    | 改用 `npm install -g bailian-cli`                                                              |
+| Windows `bl update` 失败 | 旧布局 / 文件锁 / 网络       | 重跑 `irm .../install.ps1 \| iex` 迁移布局后重试                                               |
+| `plugin` 需要 npm        | 二进制安装无本机 npm         | 安装 Node，或改用 npm 版 CLI                                                                   |
+| 安装报错 engines         | Node 版本过低（仅 npm 路径） | 升级到 ≥ 18.17.0                                                                               |
 | `bl skill init` 失败     | 网络 / registry 不可达等     | 有 Node 且有 Git 时降级 `npx skills@1.5.18 add modelstudioai/cli --all -g`；否则重试或告知用户 |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,22 +13,25 @@ npm install -g bailian-cli
 ```
 
 4. 校验：`bl --version`。
+5. 按下方「安装 skills」安装。
 
-安装 skills（CLI 内置，无需 Git / npx skills）：
+### 安装 skills
+
+**Supported（优先）：** 用 CLI 内置命令一次装齐 registry 中全部 `bailian-*`（含共享协议 `bailian-protocol`）：
 
 ```bash
 bl skill init
 ```
 
-**Supported：** `bl skill init` 一次装齐 registry 中全部 `bailian-*`（含共享协议 `bailian-protocol`）。
-
-**Advanced / 按需子集：**
+**降级：** 若 `bl skill init` 失败，且本机有可用 Node / npm（`node -v` / `npm -v` 成功），再回退到：
 
 ```bash
-bl skill add --name bailian-protocol,bailian-gen
+npx skills add modelstudioai/cli --all -g
 ```
 
-安装成功后，用中文简要说明已安装的 skills 及用户可做什么。
+无 Node 时不要走 `npx` 降级；向用户说明 skill 安装失败，并保留 `bl skill init` 的错误信息。
+
+安装成功后，按第 5 节向用户说明语言切换与能力 tip（若也装了 skills，一并简要说明）。
 
 ## 2. 备选：二进制安装（无需 Node）
 
@@ -67,8 +70,6 @@ bl --version
 which bl   # Windows: where.exe bl
 ```
 
-若自动 skill 安装失败，再手动执行：`bl skill init`。
-
 > CDN / GitHub Release 未就绪或下载失败时，若本机已有合格 Node，回退到上方 npm 安装。
 
 ---
@@ -99,12 +100,43 @@ which bl   # Windows: where.exe bl
 bl auth status --output json
 ```
 
-## 5. 常见问题
+## 5. 安装成功后向用户说明（必做）
 
-| 现象                     | 可能原因                     | 建议动作                                         |
-| ------------------------ | ---------------------------- | ------------------------------------------------ |
-| `bl: command not found`  | bin 不在 PATH                | 检查 `~/.local/bin` 或 `npm prefix -g`           |
-| curl 安装 404            | GitHub Release 资产未上传    | 改用 `npm install -g bailian-cli`                |
-| Windows `bl update` 失败 | 旧布局 / 文件锁 / 网络       | 重跑 `irm .../install.ps1 \| iex` 迁移布局后重试 |
-| `plugin` 需要 npm        | 二进制安装无本机 npm         | 安装 Node，或改用 npm 版 CLI                     |
-| 安装报错 engines         | Node 版本过低（仅 npm 路径） | 升级到 ≥ 18.17.0                                 |
+安装与校验完成后，**主动**用中文向用户说明下列两项；不要等用户追问。可执行 `bl`（已登录时）对照终端 tip，但以下列表为准，勿臆造。
+
+### 5.1 界面语言
+
+Bailian CLI 支持中英文界面（help / 欢迎语 / Quick Start 主次文案）。默认 `en-US`，可切换为 `zh-CN`：
+
+```bash
+bl config set --key language --value zh-CN
+bl config set --key language --value en-US
+```
+
+向用户说明：可随时用上述命令切换语言。
+
+### 5.2 能力 tip（Quick Start）
+
+向用户展示「试试使用Bailian CLI完成这些任务」及下列 5 条（中英各一行，与 `bl` 根帮助 tip 一致）：
+
+1. 帮我创建一个能够生成短片分镜和视频的 Managed Agent。  
+   Help me create a Managed Agent that can generate short-film storyboards and videos.
+2. 生成一张穿着太空服的猫站在火星上的图片，再把它制作成一段视频。  
+   Generate an image of a cat in a spacesuit standing on Mars, then turn it into a video.
+3. 查看最近的模型用量、免费额度和限流情况。  
+   Check my recent model usage, free quota, and rate limits.
+4. 推荐一个适合图片理解和智能客服的模型。  
+   Recommend a model suitable for image understanding and intelligent customer service.
+5. 介绍一下 Bailian CLI 能帮我完成哪些任务，并根据我的需求推荐使用方式。  
+   Explain what Bailian CLI can help me accomplish, and recommend how to use it based on my needs.
+
+## 6. 常见问题
+
+| 现象                     | 可能原因                     | 建议动作                                                                             |
+| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------ |
+| `bl: command not found`  | bin 不在 PATH                | 检查 `~/.local/bin` 或 `npm prefix -g`                                               |
+| curl 安装 404            | GitHub Release 资产未上传    | 改用 `npm install -g bailian-cli`                                                    |
+| Windows `bl update` 失败 | 旧布局 / 文件锁 / 网络       | 重跑 `irm .../install.ps1 \| iex` 迁移布局后重试                                     |
+| `plugin` 需要 npm        | 二进制安装无本机 npm         | 安装 Node，或改用 npm 版 CLI                                                         |
+| 安装报错 engines         | Node 版本过低（仅 npm 路径） | 升级到 ≥ 18.17.0                                                                     |
+| `bl skill init` 失败     | 网络 / registry 不可达等     | 有 Node 时降级 `npx skills add modelstudioai/cli --all -g`；无 Node 则重试或告知用户 |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,13 +23,13 @@ npm install -g bailian-cli
 bl skill init
 ```
 
-**降级：** 若 `bl skill init` 失败，且本机有可用 Node / npm（`node -v` / `npm -v` 成功），再回退到：
+**降级：** 若 `bl skill init` 失败，先确认本机同时满足两个条件：`node -v` / `npm -v` 成功，**且** `git --version` 成功。两个条件都成立时，再回退到：
 
 ```bash
-npx skills add modelstudioai/cli --all -g
+npx skills@1.5.18 add modelstudioai/cli --all -g
 ```
 
-无 Node 时不要走 `npx` 降级；向用户说明 skill 安装失败，并保留 `bl skill init` 的错误信息。
+> 必须使用 `skills@1.5.18`：这是最后兼容 Node ≥18 的版本（与 Bailian CLI 的 Node ≥18.17.0 一致）；
 
 安装成功后，按第 5 节向用户说明语言切换与能力 tip（若也装了 skills，一并简要说明）。
 
@@ -139,4 +139,4 @@ bl config set --key language --value en-US
 | Windows `bl update` 失败 | 旧布局 / 文件锁 / 网络       | 重跑 `irm .../install.ps1 \| iex` 迁移布局后重试                                     |
 | `plugin` 需要 npm        | 二进制安装无本机 npm         | 安装 Node，或改用 npm 版 CLI                                                         |
 | 安装报错 engines         | Node 版本过低（仅 npm 路径） | 升级到 ≥ 18.17.0                                                                     |
-| `bl skill init` 失败     | 网络 / registry 不可达等     | 有 Node 时降级 `npx skills add modelstudioai/cli --all -g`；无 Node 则重试或告知用户 |
+| `bl skill init` 失败     | 网络 / registry 不可达等     | 有 Node 且有 Git 时降级 `npx skills@1.5.18 add modelstudioai/cli --all -g`；否则重试或告知用户 |


### PR DESCRIPTION
## Summary
- Prefer `bl skill init` after npm install, with `npx skills add` only as a Node-available fallback when init fails
- Instruct agents to tell users how to switch CLI language and to share the Quick Start capability tips after a successful install
- Document skill-init failure recovery in the FAQ