### PR TITLE
chore(release): prepare 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 [中文版](CHANGELOG.zh.md) · [README](README.md) · [Contributing](CONTRIBUTING.md)
 
+## [1.18.1] - 2026-08-28
+
+### Removed
+
+- Removed API Key validation from `bl auth login`.
+
 ## [1.18.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -6,6 +6,12 @@
 
 [English](CHANGELOG.md) · [README](README.zh.md) · [参与贡献](CONTRIBUTING.zh.md)
 
+## [1.18.1] - 2026-08-28
+
+### 已移除
+
+- 移除 `bl auth login` 的 API Key 校验。
+
 ## [1.18.0] - 2026-08-27
 
 ### 新增

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "CLI for Aliyun Model Studio (DashScope) AI Platform.",
   "keywords": [
     "agent",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-commands",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Command library for bailian-cli products (knowledge, memory, media, …). See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-core",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Core SDK for bailian-cli. See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/packages/kscli/package.json
+++ b/packages/kscli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-studio-cli",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Lightweight RAG CLI for Aliyun Model Studio — focused on knowledge-base retrieval.",
   "keywords": [
     "alibaba-cloud",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bailian-cli-runtime",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Runtime framework for bailian-cli (createCli, registry, args, output, pipeline). See https://www.npmjs.com/package/bailian-cli for usage.",
   "homepage": "https://bailian.console.aliyun.com/cli",
   "bugs": {

--- a/skills/bailian-cli/SKILL.md
+++ b/skills/bailian-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-cli
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-finetune/SKILL.md
+++ b/skills/bailian-finetune/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-finetune
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-gen/SKILL.md
+++ b/skills/bailian-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-gen
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-managed-agent/SKILL.md
+++ b/skills/bailian-managed-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-managed-agent
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-protocol/SKILL.md
+++ b/skills/bailian-protocol/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-protocol
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-

--- a/skills/bailian-web-search/SKILL.md
+++ b/skills/bailian-web-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bailian-web-search
 metadata:
-  version: "1.18.0"
+  version: "1.18.1"
   requires:
     bins: ["bl"]
 description: >-


### PR DESCRIPTION
## Summary

- bump the five lockstep packages and Bailian Skill metadata to `1.18.1`
- add concise English and Chinese changelog entries for removing API Key validation from `bl auth login`

## Validation

- pre-commit `pnpm run sync:skill-assets`
- pre-commit `vp staged`
- verified the PR diff contains only release metadata and changelog changes