### PR TITLE
Fix video task failure details in task get and download

### DIFF
--- a/packages/commands/src/commands/video/download.ts
+++ b/packages/commands/src/commands/video/download.ts
@@ -53,10 +53,15 @@ export default defineCommand({
     });
 
     if (taskInfo.output.task_status !== "SUCCEEDED") {
+      const status = taskInfo.output.task_status;
+      const detail = taskInfo.output.message || taskInfo.output.code;
+      const message = detail
+        ? `Task is not complete (status: ${status}): ${detail}`
+        : `Task is not complete (status: ${status}).`;
       throw new BailianError(
-        `Task is not complete (status: ${taskInfo.output.task_status}).`,
+        message,
         ExitCode.GENERAL,
-        "Wait for the task to complete before downloading.",
+        status === "FAILED" ? undefined : "Wait for the task to complete before downloading.",
       );
     }
 

--- a/packages/commands/src/commands/video/task-get.ts
+++ b/packages/commands/src/commands/video/task-get.ts
@@ -2,6 +2,7 @@ import {
   defineCommand,
   taskPath,
   detectOutputFormat,
+  stripUndefined,
   type DashScopeTaskResponse,
 } from "bailian-cli-core";
 import { emitResult, emitBare } from "bailian-cli-runtime";
@@ -42,15 +43,20 @@ export default defineCommand({
       return;
     }
 
+    // 透传服务端失败字段：FAILED 时 output.code / output.message 是排查依据；request_id 便于工单溯源。
     emitResult(
-      {
+      stripUndefined({
         task_id: response.output.task_id,
         task_status: response.output.task_status,
         video_url: response.output.video_url,
         results: response.output.results,
         submit_time: response.output.submit_time,
+        scheduled_time: response.output.scheduled_time,
         end_time: response.output.end_time,
-      },
+        code: response.output.code,
+        message: response.output.message,
+        request_id: response.request_id,
+      }),
       format,
     );
   },


### PR DESCRIPTION
## Summary
- Surface provider `code`/`message`/`request_id` from `bl video task get` so FAILED async tasks are diagnosable (fixes #184)
- Include the same failure detail when `bl video download` rejects a non-SUCCEEDED task instead of only reporting status